### PR TITLE
Fix marker sampling, add RData state and add support for JTAG-to-SWD sequence.

### DIFF
--- a/src/SWDAnalyzer.cpp
+++ b/src/SWDAnalyzer.cpp
@@ -41,6 +41,7 @@ void SWDAnalyzer::WorkerThread()
     // on calls to IsOperation or IsLineReset
     SWDOperation tran;
     SWDLineReset reset;
+    SWDJtagToSwd jtagToSwd;
     SWDBit error_bit;
 
     mSWDParser.Clear();
@@ -63,6 +64,11 @@ void SWDAnalyzer::WorkerThread()
         {
             reset.AddFrames( mResults.get() );
 
+            mResults->CommitResults();
+        }
+        else if( mSWDParser.IsJtagToSwd( jtagToSwd ) )
+        {
+            jtagToSwd.AddFrames( mResults.get() );
             mResults->CommitResults();
         }
         else

--- a/src/SWDAnalyzerResults.cpp
+++ b/src/SWDAnalyzerResults.cpp
@@ -69,6 +69,13 @@ void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase display_base
         results.push_back( "reset" );
         results.push_back( "Line Reset" );
     }
+    else if ( f.mType == SWDFT_JtagToSwd )
+    {
+        results.push_back( "JTAG to SWD sequence" );
+        results.push_back( "JtS" );
+        results.push_back( "JTAGtoSWD" );
+        results.push_back( "JTAG to SWD" );
+    }
     else if( f.mType == SWDFT_Turnaround )
     {
         results.push_back( "Turnaround" );
@@ -102,18 +109,18 @@ void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase display_base
 
         results.push_back( "ACK" );
     }
-    else if( f.mType == SWDFT_WData )
+    else if( ( f.mType == SWDFT_WData ) || ( f.mType == SWDFT_RData ) )
     {
         std::string data_str( int2str_sal( f.mData1, display_base, 32 ) );
         SWDRegisters reg( SWDRegisters( f.mData2 ) );
         std::string reg_name( GetRegisterName( reg ) );
         std::string reg_value( GetRegisterValueDesc( reg, U32( f.mData1 ), display_base ) );
-
+        std::string prefix = ( f.mType == SWDFT_WData ) ? "WData" : "RData";
         if( !reg_value.empty() )
-            results.push_back( "WData " + data_str + " reg " + reg_name + " bits " + reg_value );
-        results.push_back( "WData " + data_str + " reg " + reg_name );
-        results.push_back( "WData" );
-        results.push_back( "WData " + data_str );
+            results.push_back( prefix + " " + data_str + " reg " + reg_name + " bits " + reg_value );
+        results.push_back( prefix + " " + data_str + " reg " + reg_name );
+        results.push_back( prefix );
+        results.push_back( prefix + " " + data_str );
     }
     else if( f.mType == SWDFT_DataParity )
     {
@@ -212,6 +219,13 @@ void SWDAnalyzerResults::GenerateExportFile( const char* file, DisplayBase displ
 
             record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
             record.push_back( "Line reset" );
+            SaveRecord( record, of );
+        }
+        else if( f.mType == SWDFT_JtagToSwd)
+        {
+            SaveRecord( record, of );
+            record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+            record.push_back( "JTAG to SWD Sequence" );
             SaveRecord( record, of );
         }
         else if( f.mType == SWDFT_Request )

--- a/src/SWDTypes.h
+++ b/src/SWDTypes.h
@@ -12,11 +12,13 @@ enum SWDFrameTypes
     SWDFT_Bit,
 
     SWDFT_LineReset,
+    SWDFT_JtagToSwd,
 
     SWDFT_Request,
     SWDFT_Turnaround,
     SWDFT_ACK,
     SWDFT_WData,
+    SWDFT_RData,
     SWDFT_DataParity,
     SWDFT_TrailingBits,
 };
@@ -131,6 +133,18 @@ struct SWDLineReset
     void AddFrames( AnalyzerResults* pResults );
 };
 
+struct SWDJtagToSwd
+{
+    std::vector<SWDBit> bits;
+
+    void Clear()
+    {
+        bits.clear();
+    }
+
+    void AddFrames( AnalyzerResults* pResults );
+};
+
 struct SWDRequestFrame : public Frame
 {
     // mData1 contains addr, mData2 contains the register enum
@@ -207,6 +221,7 @@ class SWDParser
 
     bool IsOperation( SWDOperation& tran );
     bool IsLineReset( SWDLineReset& reset );
+    bool IsJtagToSwd( SWDJtagToSwd& jtagToSwd );
 
     SWDBit PopFrontBit();
 };


### PR DESCRIPTION
Hello,

This PR should fix #2 and #3 (or at least improve behavior in 90% of cases).
Also, so far the analyzer always indicated the data-phase as "WData" phase, even for reads. This PR adds an "RData" phase that is used for reads.

This commit also adds a JTAG-to-SWD sequence detector, so that the line resets are easier to read.



Correct sampling edge (purple = previously, yellow = this PR):
<img width="512" alt="Screenshot 2022-05-09 at 11 47 58" src="https://user-images.githubusercontent.com/208596/167385287-9efd2e27-bf9c-49a9-9587-a1434f4eddf7.png">
<img width="509" alt="Screenshot 2022-05-09 at 11 47 36" src="https://user-images.githubusercontent.com/208596/167385298-3120300b-9561-43ea-ac1f-416b22a7bd0a.png">

RData vs WData (purple = previously, yellow = this PR):
<img width="429" alt="Screenshot 2022-05-09 at 11 46 57" src="https://user-images.githubusercontent.com/208596/167385350-e640b5b5-7df1-4b8f-ac2b-2e83cb5fe1dc.png">

JTAG to SWD sequence (purple = previously, yellow = this PR):

<img width="785" alt="Screenshot 2022-05-09 at 11 48 17" src="https://user-images.githubusercontent.com/208596/167385408-7dc57c11-5cec-4e64-a0b5-27a1f898db89.png">
<img width="785" alt="Screenshot 2022-05-09 at 11 48 35" src="https://user-images.githubusercontent.com/208596/167385419-aabd321a-e4c0-46db-aed3-95c950630bce.png">

Let me know what you think.

Thanks,
Thomas
