### PR TITLE
SWD Analyzer plugin improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ src/SWDTypes.cpp
 src/SWDTypes.h
 src/SWDUtils.cpp
 src/SWDUtils.h
+src/VersionInfo.h
+src/VersionInfo.cpp
 )
 
 add_analyzer_plugin(swd_analyzer SOURCES ${SOURCES})
+
+add_custom_command(TARGET ${CMAKE_PROJECT_NAME} PRE_BUILD COMMAND ${CMAKE_COMMAND} -P "${CMAKE_SOURCE_DIR}/src/PluginVersion.cmake")

--- a/cmake/ExternalAnalyzerSDK.cmake
+++ b/cmake/ExternalAnalyzerSDK.cmake
@@ -1,7 +1,7 @@
 include(FetchContent)
 
-# Use the C++11 standard
-set(CMAKE_CXX_STANDARD 11)
+# Use the C++17 standard
+set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 

--- a/src/PluginVersion.cmake
+++ b/src/PluginVersion.cmake
@@ -1,0 +1,41 @@
+# Get repo clean status from git
+execute_process(
+    COMMAND git diff --quiet --exit-code
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    RESULT_VARIABLE GIT_REPO_CHANGED
+)
+#message("Info: Git repo changed is ${GIT_REPO_CHANGED} (0 - Not changed, 1 - Changed)")
+
+if(${GIT_REPO_CHANGED} EQUAL 0)
+    # Get hash of last commit
+    execute_process(
+        COMMAND git log -1 --format=%h
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+else()
+    # Since there are changes in repo detected hash will be zeroed
+    set(GIT_COMMIT_HASH "0000000")
+endif()
+#message("Info: Git hash is ${GIT_COMMIT_HASH}")
+
+execute_process(
+    COMMAND git rev-list --all --count
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_REV_COUNT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+#message("Info: Git revisions count is ${GIT_REV_COUNT}")
+math(EXPR GIT_BUILD "${GIT_REV_COUNT}+${GIT_REPO_CHANGED}")
+#message("Info: Build #${GIT_BUILD}")
+
+# Hardcode version parts
+set(PROJECT_VERSION_MAJOR 2)
+set(PROJECT_VERSION_MINOR 0)
+set(PROJECT_VERSION_PATCH 0)
+math(EXPR PROJECT_VERSION_BUILD "${GIT_REV_COUNT}+${GIT_REPO_CHANGED}")
+message("Info: Version ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_BUILD} ... ${GIT_COMMIT_HASH}")
+
+message("Info: Updating ${CMAKE_SOURCE_DIR}/../src/VersionInfo.cpp")
+file(WRITE ${CMAKE_SOURCE_DIR}/../src/VersionInfo.cpp "#include \"VersionInfo.h\"\n\nconst struct VersionInfo VersionInfo =\n{\n  ${PROJECT_VERSION_MAJOR}u,\n  ${PROJECT_VERSION_MINOR}u,\n  ${PROJECT_VERSION_PATCH}u,\n  ${PROJECT_VERSION_BUILD}u,\n  __DATE__,\n  __TIME__,\n  \"${GIT_COMMIT_HASH}\"\n};\n")

--- a/src/PluginVersion.cmake
+++ b/src/PluginVersion.cmake
@@ -38,4 +38,4 @@ math(EXPR PROJECT_VERSION_BUILD "${GIT_REV_COUNT}+${GIT_REPO_CHANGED}")
 message("Info: Version ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}.${PROJECT_VERSION_BUILD} ... ${GIT_COMMIT_HASH}")
 
 message("Info: Updating ${CMAKE_SOURCE_DIR}/../src/VersionInfo.cpp")
-file(WRITE ${CMAKE_SOURCE_DIR}/../src/VersionInfo.cpp "#include \"VersionInfo.h\"\n\nconst struct VersionInfo VersionInfo =\n{\n  ${PROJECT_VERSION_MAJOR}u,\n  ${PROJECT_VERSION_MINOR}u,\n  ${PROJECT_VERSION_PATCH}u,\n  ${PROJECT_VERSION_BUILD}u,\n  __DATE__,\n  __TIME__,\n  \"${GIT_COMMIT_HASH}\"\n};\n")
+file(WRITE ${CMAKE_SOURCE_DIR}/../src/VersionInfo.cpp "#include \"VersionInfo.h\"\n\nconst struct VersionInfo VERSION_INFO =\n{\n  ${PROJECT_VERSION_MAJOR}u,\n  ${PROJECT_VERSION_MINOR}u,\n  ${PROJECT_VERSION_PATCH}u,\n  ${PROJECT_VERSION_BUILD}u,\n  __DATE__,\n  __TIME__,\n  \"${GIT_COMMIT_HASH}\"\n};\n")

--- a/src/SWDAnalyzer.cpp
+++ b/src/SWDAnalyzer.cpp
@@ -85,7 +85,7 @@ const std::vector<SWDAnalyzer::SWDSequenceCondition> SWDAnalyzer::SEQUENCE_CONDI
 };
 
 
-SWDAnalyzer::SWDAnalyzer() : mSWDIO(), mSWCLK(), mSimulationInitilized( false )
+SWDAnalyzer::SWDAnalyzer() : Analyzer2(), mSWDIO(), mSWCLK(), mSimulationInitilized( false )
 {
     SetAnalyzerSettings( &mSettings );
 }
@@ -149,7 +149,7 @@ void SWDAnalyzer::WorkerThread()
                             mResults->CommitResults();
                             errorBits.Clear();
                         }
-                        const SWDBaseSequnce& sequence = std::invoke( cond.GetSequence, mSWDParser );
+                        SWDBaseSequnce& sequence = std::invoke( cond.GetSequence, mSWDParser );
                         sequence.AddFrames( mResults.get() );
                         sequence.AddMarkers( mResults.get() );
 
@@ -164,7 +164,7 @@ void SWDAnalyzer::WorkerThread()
         if( !conditionMeet )
         {
             // This is neither a valid transaction nor a valid reset,
-            // so collect these bits and go forwarrd.
+            // so collect these bits and go forward.
             mSWDParser.BufferBits( 1 ); // Make sure at least one bit is placed on the buffer
             errorBits.bits.push_back( mSWDParser.PopFrontBit() );
             mSWDParser.SetErrorBits();

--- a/src/SWDAnalyzer.cpp
+++ b/src/SWDAnalyzer.cpp
@@ -41,6 +41,7 @@ void SWDAnalyzer::WorkerThread()
     // on calls to IsOperation or IsLineReset
     SWDOperation tran;
     SWDLineReset reset;
+    SWDJtagToSwd jtagToSwd;
     SWDBit error_bit;
 
     mSWDParser.Clear();
@@ -63,6 +64,11 @@ void SWDAnalyzer::WorkerThread()
         {
             reset.AddFrames( mResults.get() );
 
+            mResults->CommitResults();
+        }
+        else if( mSWDParser.IsJtagToSwd( jtagToSwd ) )
+        {
+            jtagToSwd.AddFrames( mResults.get() );
             mResults->CommitResults();
         }
         else

--- a/src/SWDAnalyzer.h
+++ b/src/SWDAnalyzer.h
@@ -41,16 +41,12 @@ class SWDAnalyzer : public Analyzer2
 
     bool mSimulationInitilized;
 
-    struct SWDSequenceCondition
-    {
-        std::set<DebugProtocol> protocols;
-        std::set<SwdFrameTypes> previousFrames;
-        bool ( SWDParser::*CompareFn )();
-        SWDBaseSequnce& ( SWDParser::*GetSequence )();
-        void ( SWDParser::*UpdateStatus )();
-    };
-
-    static const std::vector<SWDSequenceCondition> SEQUENCE_CONDITIONS;
+    // Sequence matching results
+    SeqCmpResult bestFixedLengthCmpResult = SeqCmpResult::SEQ_UNKNOWN;
+    SeqCmpResult bestVariableLengthCmpResult = SeqCmpResult::SEQ_UNKNOWN;
+    std::size_t bestPartialyMatched = 0u;
+    std::size_t bestCompleteMatched = 0u;
+    void ClearBestMatchingResults();
 };
 
 extern "C" ANALYZER_EXPORT const char* __cdecl GetAnalyzerName();

--- a/src/SWDAnalyzer.h
+++ b/src/SWDAnalyzer.h
@@ -46,7 +46,7 @@ class SWDAnalyzer : public Analyzer2
         std::set<DebugProtocol> protocols;
         std::set<SwdFrameTypes> previousFrames;
         bool ( SWDParser::*CompareFn )();
-        const SWDBaseSequnce& ( SWDParser::*GetSequence )() const;
+        SWDBaseSequnce& ( SWDParser::*GetSequence )();
         void ( SWDParser::*UpdateStatus )();
     };
 

--- a/src/SWDAnalyzer.h
+++ b/src/SWDAnalyzer.h
@@ -1,6 +1,8 @@
 #ifndef SWD_ANALYZER_H
 #define SWD_ANALYZER_H
 
+#include <set>
+
 #include <Analyzer.h>
 
 #include "SWDAnalyzerSettings.h"
@@ -14,18 +16,21 @@ class SWDAnalyzer : public Analyzer2
   public:
     SWDAnalyzer();
     virtual ~SWDAnalyzer();
-    virtual void SetupResults();
-    virtual void WorkerThread();
+    virtual void SetupResults() override;
+    virtual void WorkerThread() override;
 
-    virtual U32 GenerateSimulationData( U64 newest_sample_requested, U32 sample_rate, SimulationChannelDescriptor** simulation_channels );
-    virtual U32 GetMinimumSampleRateHz();
+    virtual U32 GenerateSimulationData( U64 newestSampleRequested, U32 sampleRate,
+                                        SimulationChannelDescriptor** simulationChannels ) override;
+    virtual U32 GetMinimumSampleRateHz() override;
 
-    virtual const char* GetAnalyzerName() const;
-    virtual bool NeedsRerun();
+    virtual const char* GetAnalyzerName() const override;
+    virtual bool NeedsRerun() override;
+
+    DPVersion GetDPVersion() const;
 
   protected: // vars
     SWDAnalyzerSettings mSettings;
-    std::auto_ptr<SWDAnalyzerResults> mResults;
+    std::unique_ptr<SWDAnalyzerResults> mResults;
 
     AnalyzerChannelData* mSWDIO;
     AnalyzerChannelData* mSWCLK;
@@ -35,6 +40,17 @@ class SWDAnalyzer : public Analyzer2
     SWDParser mSWDParser;
 
     bool mSimulationInitilized;
+
+    struct SWDSequenceCondition
+    {
+        std::set<DebugProtocol> protocols;
+        std::set<SwdFrameTypes> previousFrames;
+        bool ( SWDParser::*CompareFn )();
+        const SWDBaseSequnce& ( SWDParser::*GetSequence )() const;
+        void ( SWDParser::*UpdateStatus )();
+    };
+
+    static const std::vector<SWDSequenceCondition> SEQUENCE_CONDITIONS;
 };
 
 extern "C" ANALYZER_EXPORT const char* __cdecl GetAnalyzerName();

--- a/src/SWDAnalyzerResults.cpp
+++ b/src/SWDAnalyzerResults.cpp
@@ -75,7 +75,7 @@ void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase displayBase,
     {
         case static_cast<U8>(SwdFrameTypes::SWD_FT_REQUEST):
             {
-                SWDRequestFrame& req( ( SWDRequestFrame& )f );
+                const SWDRequestFrame& req = static_cast<const SWDRequestFrame&>(f);
 
                 std::string regName( req.GetRegisterName() );
 
@@ -128,25 +128,25 @@ void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase displayBase,
             }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_JTAG_TO_SWD):
-            results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "JTAG to SWD sequence " +
+            results.push_back( std::string( f.mFlags == 0u ? "" : "Deprecated " ) + "JTAG to SWD sequence " +
                            Int2StrSal( f.mData1, displayBase, 16 ) );
             if( !onlyFirstResult )
             {
-                results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "JTAG to SWD " +
+                results.push_back( std::string( f.mFlags == 0u ? "" : "Deprecated " ) + "JTAG to SWD " +
                                    Int2StrSal( f.mData1, displayBase, 16 ) );
-                results.push_back( std::string( f.mFlags == 0 ? "" : "Depr" ) + "JTAGtoSWD" );
-                results.push_back( std::string( f.mFlags == 0 ? "" : "D" ) + "JtS" );
+                results.push_back( std::string( f.mFlags == 0u ? "" : "Depr" ) + "JTAGtoSWD" );
+                results.push_back( std::string( f.mFlags == 0u ? "" : "D" ) + "JtS" );
             }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_SWD_TO_JTAG):
-            results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "SWD to JTAG sequence " +
+            results.push_back( std::string( f.mFlags == 0u ? "" : "Deprecated " ) + "SWD to JTAG sequence " +
                            Int2StrSal( f.mData1, displayBase, 16 ) );
             if( !onlyFirstResult )
             {
-                results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "SWD to JTAG " +
+                results.push_back( std::string( f.mFlags == 0u ? "" : "Deprecated " ) + "SWD to JTAG " +
                                    Int2StrSal( f.mData1, displayBase, 16 ) );
-                results.push_back( std::string( f.mFlags == 0 ? "" : "Depr" ) + "SWDtoJTAG" );
-                results.push_back( std::string( f.mFlags == 0 ? "" : "D" ) + "StJ" );
+                results.push_back( std::string( f.mFlags == 0u ? "" : "Depr" ) + "SWDtoJTAG" );
+                results.push_back( std::string( f.mFlags == 0u ? "" : "D" ) + "StJ" );
             }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_TURNAROUND):

--- a/src/SWDAnalyzerResults.cpp
+++ b/src/SWDAnalyzerResults.cpp
@@ -47,10 +47,11 @@ void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase display_base
         SWDRequestFrame& req( ( SWDRequestFrame& )f );
 
         std::string addr_str( int2str_sal( req.GetAddr(), display_base, 4 ) );
+        std::string reg_hex( int2str_sal( req.mData1, display_base, 4 ) );
         std::string reg_name( req.GetRegisterName() );
 
         results.push_back( std::string( "Request " ) + ( req.IsAccessPort() ? " AccessPort" : " DebugPort" ) +
-                           ( req.IsRead() ? " Read" : " Write" ) + " " + reg_name );
+                           ( req.IsRead() ? " Read" : " Write" ) + " " + reg_name + " (" + reg_hex + ")" );
 
         results.push_back( int2str_sal( req.mData2, display_base ) );
         results.push_back( "rq" );

--- a/src/SWDAnalyzerResults.cpp
+++ b/src/SWDAnalyzerResults.cpp
@@ -9,6 +9,31 @@
 #include "SWDAnalyzerSettings.h"
 #include "SWDUtils.h"
 
+std::string GetActivatedProtocolName( const U8 activationCode )
+{
+    std::string protocolName;
+    switch( activationCode )
+    {
+        case 0x00u:
+        case 0x0Au:
+            protocolName = "JTAG";
+            break;
+        case 0x1Au:
+            protocolName = "SWD";
+            break;
+        default:
+            protocolName = "Unknown";
+            break;
+    }
+    return protocolName;
+}
+
+std::string GetDSSelAlertSeq( const U64 data1, const U64 data2, DisplayBase displayBase )
+{
+    return Int2StrSal( data1 >> 32u, displayBase, 32 ) + " " + Int2StrSal( data1 & 0xFFFFFFFFu, displayBase, 32 ) + " " + 
+            Int2StrSal( data2 >> 32u, displayBase, 32 ) + " " + Int2StrSal( data2 & 0xFFFFFFFFu, displayBase, 32 );
+}
+
 SWDAnalyzerResults::SWDAnalyzerResults( SWDAnalyzer* analyzer, SWDAnalyzerSettings* settings )
     : mSettings( settings ), mAnalyzer( analyzer )
 {
@@ -41,9 +66,10 @@ SWDAnalyzerSettings* SWDAnalyzerResults::GetSettings() const
     return mSettings;
 }
 
-void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase displayBase, std::vector<std::string>& results )
+void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase displayBase, std::vector<std::string>& results, bool onlyFirstResult )
 {
     results.clear();
+    results.reserve( onlyFirstResult ? 1u : 5u ); // Reserve one or five items in advance.
 
     switch( f.mType )
     {
@@ -55,139 +81,173 @@ void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase displayBase,
 
                 results.push_back( std::string( "Request " ) + ( req.IsAccessPort() ? " AccessPort" : " DebugPort" ) +
                            ( req.IsRead() ? " Read" : " Write" ) + " " + regName );
-
-                results.push_back( Int2StrSal( req.mData2, displayBase ) );
-                results.push_back( "rq" );
-                results.push_back( "req" );
-                results.push_back( "request" );
-                results.push_back( std::string( "request " ) + ( req.IsAccessPort() ? "AP" : "DP" ) + ( req.IsRead() ? " R" : " W" ) + " " +
-                           regName );
-
-                results.push_back( std::string( "Request " ) + ( req.IsAccessPort() ? "AccessPort" : "DebugPort" ) +
-                           ( req.IsRead() ? " Read" : " Write" ) + " " + regName );
+                if( !onlyFirstResult )
+                {
+                    results.push_back( std::string( "request " ) + ( req.IsAccessPort() ? "AP" : "DP" ) + ( req.IsRead() ? " R" : " W" ) + " " +
+                                   regName );
+                    results.push_back( "request" );
+                    results.push_back( "req" );
+                    results.push_back( "rq" );
+                }
             }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_LINE_RESET):
             results.push_back( "Line Reset " + Int2Str( f.mData1 ) + " bits" );
-            results.push_back( "rst" );
-            results.push_back( "reset" );
-            results.push_back( "Line Reset" );
+            if( !onlyFirstResult )
+            {
+                results.push_back( "Line Reset" );
+                results.push_back( "reset" );
+                results.push_back( "rst" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_JTAG_TLR):
             results.push_back( "JTAG Test-Logic-Reset " + Int2Str( f.mData1 ) + " bits" );
-            results.push_back( "jtlr" );
-            results.push_back( "j tlr" );
-            results.push_back( "JTAG TLR" );
+            if( !onlyFirstResult )
+            {
+                results.push_back( "JTAG TLR" );
+                results.push_back( "j tlr" );
+                results.push_back( "jtlr" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_JTAG_TO_DS):
             results.push_back( "JTAG-to-DS sequence " + Int2StrSal( f.mData1, displayBase, 31 ) );
-            results.push_back( "JtDS" );
-            results.push_back( "JTAGtoDS" );
-            results.push_back( "JTAG-to-DS" );
+            if( !onlyFirstResult )
+            {
+                results.push_back( "JTAG-to-DS" );
+                results.push_back( "JTAGtoDS" );
+                results.push_back( "JtDS" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_SWD_TO_DS):
             results.push_back( "SWD-to-DS sequence " + Int2StrSal( f.mData1, displayBase, 16 ) );
-            results.push_back( "StDS" );
-            results.push_back( "SWDtoDS" );
-            results.push_back( "SWD-to-DS" );
+            if( !onlyFirstResult )
+            {
+                results.push_back( "SWD-to-DS" );
+                results.push_back( "SWDtoDS" );
+                results.push_back( "StDS" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_JTAG_TO_SWD):
             results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "JTAG to SWD sequence " +
                            Int2StrSal( f.mData1, displayBase, 16 ) );
-            results.push_back( std::string( f.mFlags == 0 ? "" : "D" ) + "JtS" );
-            results.push_back( std::string( f.mFlags == 0 ? "" : "Depr" ) + "JTAGtoSWD" );
-            results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "JTAG to SWD " +
-                            Int2StrSal( f.mData1, displayBase, 16 ) );
+            if( !onlyFirstResult )
+            {
+                results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "JTAG to SWD " +
+                                   Int2StrSal( f.mData1, displayBase, 16 ) );
+                results.push_back( std::string( f.mFlags == 0 ? "" : "Depr" ) + "JTAGtoSWD" );
+                results.push_back( std::string( f.mFlags == 0 ? "" : "D" ) + "JtS" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_SWD_TO_JTAG):
             results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "SWD to JTAG sequence " +
                            Int2StrSal( f.mData1, displayBase, 16 ) );
-            results.push_back( std::string( f.mFlags == 0 ? "" : "D" ) + "StJ" );
-            results.push_back( std::string( f.mFlags == 0 ? "" : "Depr" ) + "SWDtoJTAG" );
-            results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "SWD to JTAG " + Int2StrSal( f.mData1, displayBase, 16 ) );
+            if( !onlyFirstResult )
+            {
+                results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "SWD to JTAG " +
+                                   Int2StrSal( f.mData1, displayBase, 16 ) );
+                results.push_back( std::string( f.mFlags == 0 ? "" : "Depr" ) + "SWDtoJTAG" );
+                results.push_back( std::string( f.mFlags == 0 ? "" : "D" ) + "StJ" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_TURNAROUND):
             results.push_back( "Turnaround" );
-            results.push_back( "T" );
-            results.push_back( "trn" );
-            results.push_back( "turn" );
+            if( !onlyFirstResult )
+            {
+                results.push_back( "turn" );
+                results.push_back( "trn" );
+                results.push_back( "T" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_ACK):
             if( f.mData1 == static_cast<U64>( SWDAcks::ACK_OK ) )
             {
                 results.push_back( "ACK OK" );
-                results.push_back( "OK" );
+                if( !onlyFirstResult )
+                {
+                    results.push_back( "OK" );
+                }
             }
             else if( f.mData1 == static_cast<U64>( SWDAcks::ACK_WAIT ) )
             {
                 results.push_back( "ACK WAIT" );
-                results.push_back( "WAIT" );
+                if( !onlyFirstResult )
+                {
+                    results.push_back( "WAIT" );
+                }
             }
             else if( f.mData1 == static_cast<U64>( SWDAcks::ACK_FAULT ) )
             {
                 results.push_back( "ACK FAULT" );
-                results.push_back( "FAULT" );
+                if( !onlyFirstResult )
+                {
+                    results.push_back( "FAULT" );
+                }
             }
             else
             {
                 results.push_back( "ACK <unknown> probably disconnected" );
-                results.push_back( "ACK <unknown>" );
-                results.push_back( "disc" );
+                if( !onlyFirstResult )
+                {
+                    results.push_back( "ACK <unknown>" );
+                    results.push_back( "disc" );
+                }
             }
-            results.push_back( "ACK" );
+            if( !onlyFirstResult )
+            {
+                results.push_back( "ACK" );
+            }
             break;
-        case static_cast<U8>(SwdFrameTypes::SWD_FT_WDATA):
-        case static_cast<U8>(SwdFrameTypes::SWD_FT_RDATA):
+        case static_cast<U8>( SwdFrameTypes::SWD_FT_RDATA ):
+        case static_cast<U8>( SwdFrameTypes::SWD_FT_WDATA ):
             {
                 std::string dataStr( Int2StrSal( f.mData1, displayBase, 32 ) );
-                std::string regName;
-                std::string regValue;
-                SWDRegistersUnion swdRegCouple; // Couple of previous and current SWD register
+                SWDRegistersUnion swdRegCouple{}; // Couple of previous and current SWD register
                 swdRegCouple.blob = f.mData2;
-
-                if( swdRegCouple.reg.prev == SWDRegisters::SWDR_UNDEFINED )
+                std::string regName = GetRegisterName( swdRegCouple.reg.current );
+                std::string regValueDesc;
+                std::string prefix;
+                if( f.mType == static_cast<U8>( SwdFrameTypes::SWD_FT_RDATA ) )
                 {
-                    // DP Read except READBUFF, DP Write, AP Write
-                    regName = GetRegisterName( swdRegCouple.reg.current );
-                    regValue = GetRegisterValueDesc( swdRegCouple.reg.current, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
+                    regValueDesc = GetReadRegisterValueDesc( swdRegCouple, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
+                    prefix = "RData";
                 }
                 else
                 {
-                    if( swdRegCouple.reg.current == SWDRegisters::SWDR_UNDEFINED )
-                    {
-                        // First AP Read
-                        regName = GetRegisterName( swdRegCouple.reg.prev );
-                        regValue = "Ignored AP first read data";
-                    }
-                    else
-                    {
-                        // Next AP Reads, DP Read of READBUFF
-                        regName = GetRegisterName( swdRegCouple.reg.current );
-                        regValue = GetRegisterValueDesc( swdRegCouple.reg.prev, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
-                    }
+                    regValueDesc = GetWriteRegisterValueDesc( swdRegCouple, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
+                    prefix = "WData";
                 }
-
-                std::string prefix = ( f.mType == static_cast<U8>(SwdFrameTypes::SWD_FT_WDATA ) ) ? "WData" : "RData";
-                if( !regValue.empty() )
+                if( !regValueDesc.empty() )
                 {
-                    results.push_back( prefix + " " + dataStr + " reg " + regName + " bits " + regValue );
+                    results.push_back( prefix + " " + dataStr + " reg " + regName + " " + regValueDesc );
                 }
-                results.push_back( prefix + " " + dataStr + " reg " + regName );
-                results.push_back( prefix );
-                results.push_back( prefix + " " + dataStr );
+                if( regValueDesc.empty() || ( !onlyFirstResult ) )
+                {
+                    results.push_back( prefix + " " + dataStr + " reg " + regName );
+                }
+                if( !onlyFirstResult )
+                {
+                    results.push_back( prefix + " " + dataStr );
+                    results.push_back( prefix );
+                }
             }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_DATA_PARITY):
-            results.push_back( std::string( "Data parity" ) + ( f.mData2 ? "ok" : "NOT OK" ) );
-            results.push_back( f.mData1 ? "1" : "0" );
-            results.push_back( "prty" );
-            results.push_back( "Parity" );
+            results.push_back( std::string( "Data parity" ) + ( f.mData2 ? " ok" : " NOT OK" ) );
+            if( !onlyFirstResult )
+            {
+                results.push_back( "Parity" );
+                results.push_back( "prty" );
+                results.push_back( f.mData1 ? "1" : "0" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_IDLE_CYCLE):
             results.push_back( Int2Str( f.mData1 ) + " Idle Cycles" );
-            results.push_back( "idl" );
-            results.push_back( "idle" );
-            results.push_back( "Idle Cycles" );
+            if( !onlyFirstResult )
+            {
+                results.push_back( "Idle Cycles" );
+                results.push_back( "idle" );
+                results.push_back( "idl" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_ERROR):
             {
@@ -197,9 +257,12 @@ void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase displayBase,
                     protocolName += "SWD ";
                 }
                 results.push_back( "Erroneus " + protocolName + Int2Str( f.mData1 ) + " bits" );
-                results.push_back( "e" );
-                results.push_back( "err" );
-                results.push_back( "Erroneus " + protocolName + "bits" );
+                if( !onlyFirstResult )
+                {
+                    results.push_back( "Erroneus " + protocolName + "bits" );
+                    results.push_back( "err" );
+                    results.push_back( "e" );
+                }
             }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_IGNORED):
@@ -217,50 +280,49 @@ void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase displayBase,
                     }
                 }
                 results.push_back( "Ignored " + protocolName + Int2Str( f.mData1 ) + " bits" );
-                results.push_back( "i" );
-                results.push_back( "ign" );
-                results.push_back( "Ignored " + protocolName + "bits" );
+                if( !onlyFirstResult )
+                {
+                    results.push_back( "Ignored " + protocolName + "bits" );
+                    results.push_back( "ign" );
+                    results.push_back( "i" );
+                }
             }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_DS_SEL_ALERT_PREAMBLE):
             results.push_back( "DS Selection Alert sequence preamble " + Int2Str( f.mData1 ) + " bits" );
-            results.push_back( "dssap" );
-            results.push_back( "ds sap" );
-            results.push_back( "DS SA preamble" );
+            if( !onlyFirstResult )
+            {
+                results.push_back( "DS SA preamble" );
+                results.push_back( "ds sap" );
+                results.push_back( "dssap" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_DS_SEL_ALERT):
-            results.push_back( "DS Selection Alert sequence " + Int2StrSal( f.mData1, displayBase, 64 ) + " " +
-                               Int2StrSal( f.mData2, displayBase, 31 ) );
-            results.push_back( "dssa" );
-            results.push_back( "ds sa" );
-            results.push_back( "DS SA" );
+            results.push_back( "DS Selection Alert sequence " + GetDSSelAlertSeq( f.mData1, f.mData2, displayBase ) );
+            if( !onlyFirstResult )
+            {
+                results.push_back( "DS SA" );
+                results.push_back( "dssa" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE_PREAMBLE):
             results.push_back( "DS Activation code sequence preamble " + Int2Str( f.mData1 ) + " bits" );
-            results.push_back( "dsacp" );
-            results.push_back( "ds acp" );
-            results.push_back( "DS AC preamble" );
+            if( !onlyFirstResult )
+            {
+                results.push_back( "DS AC preamble" );
+                results.push_back( "ds acp" );
+                results.push_back( "dsacp" );
+            }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE):
             {
-                std::string protocolName;
-                switch( f.mData1 )
+                results.push_back( "DS Activation code sequence " + Int2StrSal( f.mData1, displayBase, 8 ) + " (" +
+                                   GetActivatedProtocolName( static_cast<U8>( f.mData1 ) ) + ")" );
+                if( !onlyFirstResult )
                 {
-                    case 0x00u:
-                    case 0x0Au:
-                        protocolName = "JTAG";
-                        break;
-                    case 0x1Au:
-                        protocolName = "SWD";
-                        break;
-                    default:
-                        protocolName = "Unknown";
-                        break;
+                    results.push_back( "DS AC" );
+                    results.push_back( "dsac" );
                 }
-                results.push_back( "DS Activation code sequence " + Int2StrSal( f.mData1, displayBase, 8 ) + " (" + protocolName + ")" );
-                results.push_back( "dsac" );
-                results.push_back( "ds ac" );
-                results.push_back( "DS AC" );
             }
             break;
         case static_cast<U8>(SwdFrameTypes::SWD_FT_BIT):
@@ -281,7 +343,7 @@ void SWDAnalyzerResults::GenerateBubbleText( U64 frameIndex, Channel& channel, D
     Frame f = GetFrame( frameIndex );
 
     std::vector<std::string> results;
-    GetBubbleText( f, displayBase, results );
+    GetBubbleText( f, displayBase, results, false );
 
     for( std::vector<std::string>::iterator ri( results.begin() ); ri != results.end(); ++ri )
         AddResultString( ri->c_str() );
@@ -389,7 +451,7 @@ void SWDAnalyzerResults::GenerateExportFile( const char* file, DisplayBase displ
             case static_cast<U8>( SwdFrameTypes::SWD_FT_DS_SEL_ALERT ):
                 SaveRecord( record, of );
                 record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
-                record.push_back( "DS Selection Alert sequence " + Int2StrSal( f.mData1, displayBase, 64 ) + " " + Int2StrSal( f.mData2, displayBase, 31 ) );
+                record.push_back( "DS Selection Alert sequence " + GetDSSelAlertSeq( f.mData1, f.mData2, displayBase ) );
                 SaveRecord( record, of );
                 break;
             case static_cast<U8>( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE_PREAMBLE ):
@@ -401,23 +463,8 @@ void SWDAnalyzerResults::GenerateExportFile( const char* file, DisplayBase displ
             case static_cast<U8>( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE ):
                 SaveRecord( record, of );
                 record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
-                {
-                    std::string protocolName;
-                    switch( f.mData1 )
-                    {
-                    case 0x00u:
-                    case 0x0Au:
-                        protocolName = "JTAG";
-                        break;
-                    case 0x1Au:
-                        protocolName = "SWD";
-                        break;
-                    default:
-                        protocolName = "Unknown";
-                        break;
-                    }
-                    record.push_back( "DS Activation code sequence " + Int2StrSal( f.mData1, displayBase, 8 ) + " (" + protocolName + ")" );
-                }
+                record.push_back( "DS Activation code sequence " + Int2StrSal( f.mData1, displayBase, 8 ) + " (" +
+                                  GetActivatedProtocolName( static_cast<U8>( f.mData1 ) ) + ")" );
                 SaveRecord( record, of );
                 break;
             case static_cast<U8>( SwdFrameTypes::SWD_FT_OPERATION ):
@@ -445,32 +492,22 @@ void SWDAnalyzerResults::GenerateExportFile( const char* file, DisplayBase displ
                 else
                     record.push_back( "<disc>" );
                 break;
-            case static_cast<U8>( SwdFrameTypes::SWD_FT_WDATA ):
             case static_cast<U8>( SwdFrameTypes::SWD_FT_RDATA ):
                 record.push_back( Int2StrSal( f.mData1, displayBase, 32 ) );
                 {
-                    SWDRegistersUnion swdRegCouple; // Couple of previous and current SWD register
+                    SWDRegistersUnion swdRegCouple{}; // Couple of previous and current SWD register
                     swdRegCouple.blob = f.mData2;
-                    std::string regValue;
-
-                    if( swdRegCouple.reg.prev == SWDRegisters::SWDR_UNDEFINED )
-                    {
-                        // DP Read except READBUFF, DP Write, AP Write
-                        regValue = GetRegisterValueDesc( swdRegCouple.reg.current, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
-                    }
-                    else
-                    {
-                        if( swdRegCouple.reg.current == SWDRegisters::SWDR_UNDEFINED )
-                        {
-                            // First AP Read
-                            regValue = "Ignored AP first read data";
-                        }
-                        else
-                        {
-                            // Next AP Reads, DP Read of READBUFF
-                            regValue = GetRegisterValueDesc( swdRegCouple.reg.prev, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
-                        }
-                    }
+                    std::string regValue = GetReadRegisterValueDesc( swdRegCouple, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
+                    record.push_back( regValue );
+                }
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_WDATA ):
+                record.push_back( Int2StrSal( f.mData1, displayBase, 32 ) );
+                {
+                    SWDRegistersUnion swdRegCouple{}; // Couple of previous and current SWD register
+                    swdRegCouple.blob = f.mData2;
+                    std::string regValue = GetWriteRegisterValueDesc( swdRegCouple, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
                     record.push_back( regValue );
                 }
                 SaveRecord( record, of );
@@ -496,7 +533,7 @@ void SWDAnalyzerResults::GenerateFrameTabularText( U64 frameIndex, DisplayBase d
 
     std::vector<std::string> results;
     Frame f = GetFrame( frameIndex );
-    GetBubbleText( f, displayBase, results );
+    GetBubbleText( f, displayBase, results, true );
 
     if( !results.empty() )
         AddTabularText( results.front().c_str() );

--- a/src/SWDAnalyzerResults.cpp
+++ b/src/SWDAnalyzerResults.cpp
@@ -69,6 +69,13 @@ void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase display_base
         results.push_back( "reset" );
         results.push_back( "Line Reset" );
     }
+    else if ( f.mType == SWDFT_JtagToSwd )
+    {
+        results.push_back( "JTAG to SWD sequence" );
+        results.push_back( "JtS" );
+        results.push_back( "JTAGtoSWD" );
+        results.push_back( "JTAG to SWD" );
+    }
     else if( f.mType == SWDFT_Turnaround )
     {
         results.push_back( "Turnaround" );
@@ -102,18 +109,18 @@ void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase display_base
 
         results.push_back( "ACK" );
     }
-    else if( f.mType == SWDFT_WData )
+    else if( ( f.mType == SWDFT_WData ) || ( f.mType == SWDFT_RData ) )
     {
         std::string data_str( int2str_sal( f.mData1, display_base, 32 ) );
         SWDRegisters reg( SWDRegisters( f.mData2 ) );
         std::string reg_name( GetRegisterName( reg ) );
         std::string reg_value( GetRegisterValueDesc( reg, U32( f.mData1 ), display_base ) );
-
+        std::string prefix = ( f.mType == SWDFT_WData ) ? "WData" : "RData";
         if( !reg_value.empty() )
-            results.push_back( "WData " + data_str + " reg " + reg_name + " bits " + reg_value );
-        results.push_back( "WData " + data_str + " reg " + reg_name );
-        results.push_back( "WData" );
-        results.push_back( "WData " + data_str );
+            results.push_back( prefix + " " + data_str + " reg " + reg_name + " bits " + reg_value );
+        results.push_back( prefix + " " + data_str + " reg " + reg_name );
+        results.push_back( prefix );
+        results.push_back( prefix + " " + data_str );
     }
     else if( f.mType == SWDFT_DataParity )
     {
@@ -212,6 +219,13 @@ void SWDAnalyzerResults::GenerateExportFile( const char* file, DisplayBase displ
 
             record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
             record.push_back( "Line reset" );
+            SaveRecord( record, of );
+        }
+        else if( f.mType == SWDFT_JtagToSwd)
+        {
+            SaveRecord( record, of );
+            record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+            record.push_back( "JTAG to SWD Sequence" );
             SaveRecord( record, of );
         }
         else if( f.mType == SWDFT_Request )

--- a/src/SWDAnalyzerResults.cpp
+++ b/src/SWDAnalyzerResults.cpp
@@ -251,7 +251,7 @@ void SWDAnalyzerResults::GenerateExportFile( const char* file, DisplayBase displ
             else
                 record.push_back( "<disc>" );
         }
-        else if( f.mType == SWDFT_WData )
+        else if( (f.mType == SWDFT_WData) || (f.mType == SWDFT_RData) )
         {
             record.push_back( int2str_sal( f.mData1, display_base, 32 ) );
 

--- a/src/SWDAnalyzerResults.cpp
+++ b/src/SWDAnalyzerResults.cpp
@@ -25,150 +25,263 @@ double SWDAnalyzerResults::GetSampleTime( S64 sample ) const
 
 std::string SWDAnalyzerResults::GetSampleTimeStr( S64 sample ) const
 {
-    char time_str[ 128 ];
-    AnalyzerHelpers::GetTimeString( sample, mAnalyzer->GetTriggerSample(), mAnalyzer->GetSampleRate(), time_str, sizeof( time_str ) );
+    char timeStr[ 128 ];
+    AnalyzerHelpers::GetTimeString( sample, mAnalyzer->GetTriggerSample(), mAnalyzer->GetSampleRate(), timeStr, sizeof( timeStr ) );
 
     // remove trailing zeros
-    int l = strlen( time_str );
+    size_t l = strlen( timeStr );
     if( l > 7 )
-        time_str[ l - 7 ] = '\0';
+        timeStr[ l - 7 ] = '\0';
 
-    return time_str;
+    return timeStr;
 }
 
-void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase display_base, std::vector<std::string>& results )
+SWDAnalyzerSettings* SWDAnalyzerResults::GetSettings() const
+{
+    return mSettings;
+}
+
+void SWDAnalyzerResults::GetBubbleText( const Frame& f, DisplayBase displayBase, std::vector<std::string>& results )
 {
     results.clear();
 
-    std::string result;
+    switch( f.mType )
+    {
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_REQUEST):
+            {
+                SWDRequestFrame& req( ( SWDRequestFrame& )f );
 
-    if( f.mType == SWDFT_Request )
-    {
-        SWDRequestFrame& req( ( SWDRequestFrame& )f );
+                std::string regName( req.GetRegisterName() );
 
-        std::string addr_str( int2str_sal( req.GetAddr(), display_base, 4 ) );
-        std::string reg_hex( int2str_sal( req.mData1, display_base, 4 ) );
-        std::string reg_name( req.GetRegisterName() );
+                results.push_back( std::string( "Request " ) + ( req.IsAccessPort() ? " AccessPort" : " DebugPort" ) +
+                           ( req.IsRead() ? " Read" : " Write" ) + " " + regName );
 
-        results.push_back( std::string( "Request " ) + ( req.IsAccessPort() ? " AccessPort" : " DebugPort" ) +
-                           ( req.IsRead() ? " Read" : " Write" ) + " " + reg_name + " (" + reg_hex + ")" );
+                results.push_back( Int2StrSal( req.mData2, displayBase ) );
+                results.push_back( "rq" );
+                results.push_back( "req" );
+                results.push_back( "request" );
+                results.push_back( std::string( "request " ) + ( req.IsAccessPort() ? "AP" : "DP" ) + ( req.IsRead() ? " R" : " W" ) + " " +
+                           regName );
 
-        results.push_back( int2str_sal( req.mData2, display_base ) );
-        results.push_back( "rq" );
-        results.push_back( "req" );
-        results.push_back( "request" );
-        results.push_back( std::string( "request " ) + ( req.IsAccessPort() ? "AP" : "DP" ) + ( req.IsRead() ? " R" : " W" ) + " " +
-                           reg_name );
-
-        results.push_back( std::string( "Request " ) + ( req.IsAccessPort() ? "AccessPort" : "DebugPort" ) +
-                           ( req.IsRead() ? " Read" : " Write" ) + " " + reg_name );
-    }
-    else if( f.mType == SWDFT_LineReset )
-    {
-        results.push_back( "Line Reset " + int2str( f.mData1 ) + " bits" );
-        results.push_back( "rst" );
-        results.push_back( "reset" );
-        results.push_back( "Line Reset" );
-    }
-    else if ( f.mType == SWDFT_JtagToSwd )
-    {
-        results.push_back( "JTAG to SWD sequence" );
-        results.push_back( "JtS" );
-        results.push_back( "JTAGtoSWD" );
-        results.push_back( "JTAG to SWD" );
-    }
-    else if( f.mType == SWDFT_Turnaround )
-    {
-        results.push_back( "Turnaround" );
-        results.push_back( "T" );
-        results.push_back( "trn" );
-        results.push_back( "turn" );
-    }
-    else if( f.mType == SWDFT_ACK )
-    {
-        if( f.mData1 == ACK_OK )
-        {
-            results.push_back( "ACK OK" );
-            results.push_back( "OK" );
-        }
-        else if( f.mData1 == ACK_WAIT )
-        {
-            results.push_back( "ACK WAIT" );
-            results.push_back( "WAIT" );
-        }
-        else if( f.mData1 == ACK_FAULT )
-        {
-            results.push_back( "ACK FAULT" );
-            results.push_back( "FAULT" );
-        }
-        else
-        {
-            results.push_back( "ACK <unknown> probably disconnected" );
-            results.push_back( "ACK <unknown>" );
-            results.push_back( "disc" );
-        }
-
-        results.push_back( "ACK" );
-    }
-    else if( ( f.mType == SWDFT_WData ) || ( f.mType == SWDFT_RData ) )
-    {
-        std::string data_str( int2str_sal( f.mData1, display_base, 32 ) );
-        SWDRegisters reg( SWDRegisters( f.mData2 ) );
-        std::string reg_name( GetRegisterName( reg ) );
-        std::string reg_value( GetRegisterValueDesc( reg, U32( f.mData1 ), display_base ) );
-        std::string prefix = ( f.mType == SWDFT_WData ) ? "WData" : "RData";
-        if( !reg_value.empty() )
-            results.push_back( prefix + " " + data_str + " reg " + reg_name + " bits " + reg_value );
-        results.push_back( prefix + " " + data_str + " reg " + reg_name );
-        results.push_back( prefix );
-        results.push_back( prefix + " " + data_str );
-    }
-    else if( f.mType == SWDFT_DataParity )
-    {
-        results.push_back( std::string( "Data parity" ) + ( f.mData2 ? "ok" : "NOT OK" ) );
-        results.push_back( f.mData1 ? "1" : "0" );
-        results.push_back( "prty" );
-        results.push_back( "Parity" );
-    }
-    else if( f.mType == SWDFT_TrailingBits )
-    {
-        results.push_back( "Trailing bits" );
-        results.push_back( "Trail" );
-    }
-    else
-    {
-        std::string msg;
-
-        switch( f.mType )
-        {
-        case SWDFT_Bit:
-            msg = "bit " + int2str( f.mData2 );
+                results.push_back( std::string( "Request " ) + ( req.IsAccessPort() ? "AccessPort" : "DebugPort" ) +
+                           ( req.IsRead() ? " Read" : " Write" ) + " " + regName );
+            }
             break;
-        case SWDFT_WData:
-            msg = "data";
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_LINE_RESET):
+            results.push_back( "Line Reset " + Int2Str( f.mData1 ) + " bits" );
+            results.push_back( "rst" );
+            results.push_back( "reset" );
+            results.push_back( "Line Reset" );
             break;
-        case SWDFT_DataParity:
-            msg = "dprty";
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_JTAG_TLR):
+            results.push_back( "JTAG Test-Logic-Reset " + Int2Str( f.mData1 ) + " bits" );
+            results.push_back( "jtlr" );
+            results.push_back( "j tlr" );
+            results.push_back( "JTAG TLR" );
             break;
-        case SWDFT_Error:
-            msg = "err";
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_JTAG_TO_DS):
+            results.push_back( "JTAG-to-DS sequence " + Int2StrSal( f.mData1, displayBase, 31 ) );
+            results.push_back( "JtDS" );
+            results.push_back( "JTAGtoDS" );
+            results.push_back( "JTAG-to-DS" );
             break;
-        case SWDFT_Request:
-            msg = "request";
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_SWD_TO_DS):
+            results.push_back( "SWD-to-DS sequence " + Int2StrSal( f.mData1, displayBase, 16 ) );
+            results.push_back( "StDS" );
+            results.push_back( "SWDtoDS" );
+            results.push_back( "SWD-to-DS" );
             break;
-        }
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_JTAG_TO_SWD):
+            results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "JTAG to SWD sequence " +
+                           Int2StrSal( f.mData1, displayBase, 16 ) );
+            results.push_back( std::string( f.mFlags == 0 ? "" : "D" ) + "JtS" );
+            results.push_back( std::string( f.mFlags == 0 ? "" : "Depr" ) + "JTAGtoSWD" );
+            results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "JTAG to SWD " +
+                            Int2StrSal( f.mData1, displayBase, 16 ) );
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_SWD_TO_JTAG):
+            results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "SWD to JTAG sequence " +
+                           Int2StrSal( f.mData1, displayBase, 16 ) );
+            results.push_back( std::string( f.mFlags == 0 ? "" : "D" ) + "StJ" );
+            results.push_back( std::string( f.mFlags == 0 ? "" : "Depr" ) + "SWDtoJTAG" );
+            results.push_back( std::string( f.mFlags == 0 ? "" : "Deprecated " ) + "SWD to JTAG " + Int2StrSal( f.mData1, displayBase, 16 ) );
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_TURNAROUND):
+            results.push_back( "Turnaround" );
+            results.push_back( "T" );
+            results.push_back( "trn" );
+            results.push_back( "turn" );
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_ACK):
+            if( f.mData1 == static_cast<U64>( SWDAcks::ACK_OK ) )
+            {
+                results.push_back( "ACK OK" );
+                results.push_back( "OK" );
+            }
+            else if( f.mData1 == static_cast<U64>( SWDAcks::ACK_WAIT ) )
+            {
+                results.push_back( "ACK WAIT" );
+                results.push_back( "WAIT" );
+            }
+            else if( f.mData1 == static_cast<U64>( SWDAcks::ACK_FAULT ) )
+            {
+                results.push_back( "ACK FAULT" );
+                results.push_back( "FAULT" );
+            }
+            else
+            {
+                results.push_back( "ACK <unknown> probably disconnected" );
+                results.push_back( "ACK <unknown>" );
+                results.push_back( "disc" );
+            }
+            results.push_back( "ACK" );
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_WDATA):
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_RDATA):
+            {
+                std::string dataStr( Int2StrSal( f.mData1, displayBase, 32 ) );
+                std::string regName;
+                std::string regValue;
+                SWDRegistersUnion swdRegCouple; // Couple of previous and current SWD register
+                swdRegCouple.blob = f.mData2;
 
-        results.push_back( msg );
+                if( swdRegCouple.reg.prev == SWDRegisters::SWDR_UNDEFINED )
+                {
+                    // DP Read except READBUFF, DP Write, AP Write
+                    regName = GetRegisterName( swdRegCouple.reg.current );
+                    regValue = GetRegisterValueDesc( swdRegCouple.reg.current, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
+                }
+                else
+                {
+                    if( swdRegCouple.reg.current == SWDRegisters::SWDR_UNDEFINED )
+                    {
+                        // First AP Read
+                        regName = GetRegisterName( swdRegCouple.reg.prev );
+                        regValue = "Ignored AP first read data";
+                    }
+                    else
+                    {
+                        // Next AP Reads, DP Read of READBUFF
+                        regName = GetRegisterName( swdRegCouple.reg.current );
+                        regValue = GetRegisterValueDesc( swdRegCouple.reg.prev, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
+                    }
+                }
+
+                std::string prefix = ( f.mType == static_cast<U8>(SwdFrameTypes::SWD_FT_WDATA ) ) ? "WData" : "RData";
+                if( !regValue.empty() )
+                {
+                    results.push_back( prefix + " " + dataStr + " reg " + regName + " bits " + regValue );
+                }
+                results.push_back( prefix + " " + dataStr + " reg " + regName );
+                results.push_back( prefix );
+                results.push_back( prefix + " " + dataStr );
+            }
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_DATA_PARITY):
+            results.push_back( std::string( "Data parity" ) + ( f.mData2 ? "ok" : "NOT OK" ) );
+            results.push_back( f.mData1 ? "1" : "0" );
+            results.push_back( "prty" );
+            results.push_back( "Parity" );
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_IDLE_CYCLE):
+            results.push_back( Int2Str( f.mData1 ) + " Idle Cycles" );
+            results.push_back( "idl" );
+            results.push_back( "idle" );
+            results.push_back( "Idle Cycles" );
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_ERROR):
+            {
+                std::string protocolName( "" );
+                if( f.mData2 == static_cast<U64>( DebugProtocol::DPROTOCOL_SWD ) )
+                {
+                    protocolName += "SWD ";
+                }
+                results.push_back( "Erroneus " + protocolName + Int2Str( f.mData1 ) + " bits" );
+                results.push_back( "e" );
+                results.push_back( "err" );
+                results.push_back( "Erroneus " + protocolName + "bits" );
+            }
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_IGNORED):
+            {
+                std::string protocolName( "" );
+                if( f.mData2 == static_cast<U64>( DebugProtocol::DPROTOCOL_DORMANT ) )
+                {
+                    protocolName += "Dormant ";
+                }
+                else
+                {
+                    if( f.mData2 == static_cast<U64>( DebugProtocol::DPROTOCOL_JTAG ) )
+                    {
+                        protocolName += "JTAG ";
+                    }
+                }
+                results.push_back( "Ignored " + protocolName + Int2Str( f.mData1 ) + " bits" );
+                results.push_back( "i" );
+                results.push_back( "ign" );
+                results.push_back( "Ignored " + protocolName + "bits" );
+            }
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_DS_SEL_ALERT_PREAMBLE):
+            results.push_back( "DS Selection Alert sequence preamble " + Int2Str( f.mData1 ) + " bits" );
+            results.push_back( "dssap" );
+            results.push_back( "ds sap" );
+            results.push_back( "DS SA preamble" );
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_DS_SEL_ALERT):
+            results.push_back( "DS Selection Alert sequence " + Int2StrSal( f.mData1, displayBase, 64 ) + " " +
+                               Int2StrSal( f.mData2, displayBase, 31 ) );
+            results.push_back( "dssa" );
+            results.push_back( "ds sa" );
+            results.push_back( "DS SA" );
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE_PREAMBLE):
+            results.push_back( "DS Activation code sequence preamble " + Int2Str( f.mData1 ) + " bits" );
+            results.push_back( "dsacp" );
+            results.push_back( "ds acp" );
+            results.push_back( "DS AC preamble" );
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE):
+            {
+                std::string protocolName;
+                switch( f.mData1 )
+                {
+                    case 0x00u:
+                    case 0x0Au:
+                        protocolName = "JTAG";
+                        break;
+                    case 0x1Au:
+                        protocolName = "SWD";
+                        break;
+                    default:
+                        protocolName = "Unknown";
+                        break;
+                }
+                results.push_back( "DS Activation code sequence " + Int2StrSal( f.mData1, displayBase, 8 ) + " (" + protocolName + ")" );
+                results.push_back( "dsac" );
+                results.push_back( "ds ac" );
+                results.push_back( "DS AC" );
+            }
+            break;
+        case static_cast<U8>(SwdFrameTypes::SWD_FT_BIT):
+            {
+                std::string msg;
+                msg = "bit " + Int2Str( f.mData2 );
+                results.push_back( msg );
+            }
+            break;
+        default:
+            break;
     }
 }
 
-void SWDAnalyzerResults::GenerateBubbleText( U64 frame_index, Channel& channel, DisplayBase display_base )
+void SWDAnalyzerResults::GenerateBubbleText( U64 frameIndex, Channel& channel, DisplayBase displayBase )
 {
     ClearResultStrings();
-    Frame f = GetFrame( frame_index );
+    Frame f = GetFrame( frameIndex );
 
     std::vector<std::string> results;
-    GetBubbleText( f, display_base, results );
+    GetBubbleText( f, displayBase, results );
 
     for( std::vector<std::string>::iterator ri( results.begin() ); ri != results.end(); ++ri )
         AddResultString( ri->c_str() );
@@ -197,97 +310,205 @@ void SaveRecord( std::vector<std::string>& rec, std::ofstream& of )
     rec.clear();
 }
 
-void SWDAnalyzerResults::GenerateExportFile( const char* file, DisplayBase display_base, U32 export_type_user_id )
+void SWDAnalyzerResults::GenerateExportFile( const char* file, DisplayBase displayBase, U32 exportTypeUserId )
 {
     std::ofstream of( file, std::ios::out );
 
-    U64 trigger_sample = mAnalyzer->GetTriggerSample();
-    U32 sample_rate = mAnalyzer->GetSampleRate();
-
-    of << "Time\tType\tR/W\tAP/DP\tRegister\tRequest byte\tACK\tWData\tWData details" << std::endl;
+    of << "Time\tType\tR/W\tAP/DP\tRegister\tRequest byte\tACK\tData\tData details" << std::endl;
 
     Frame f;
-    const U64 num_frames = GetNumFrames();
+    const U64 numFrames = GetNumFrames();
     std::vector<std::string> record;
-    for( U64 fcnt = 0; fcnt < num_frames; fcnt++ )
+    for( U64 fcnt = 0; fcnt < numFrames; fcnt++ )
     {
         // get the frame
         f = GetFrame( fcnt );
 
-        if( f.mType == SWDFT_LineReset )
+        switch( f.mType )
         {
-            SaveRecord( record, of );
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_ERROR ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "Erroneus " + Int2Str( f.mData1 ) + " bits" );
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_IGNORED ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "Ignored " + Int2Str( f.mData1 ) + " bits" );
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_BIT ):
+                // Skip this type of frame
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_LINE_RESET ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "Line reset" );
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TO_SWD ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "JTAG to SWD Sequence" );
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_SWD_TO_JTAG ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "SWD to JTAG Sequence" );
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_IDLE_CYCLE ):
+                // Skip this type of frame
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TLR ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "JTAG Test-Logic-Reset " + Int2Str( f.mData1 ) + " bits" );
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TO_DS ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "JTAG-to-DS sequence " + Int2StrSal( f.mData1, displayBase, 31 ) );
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_SWD_TO_DS ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "SWD-to-DS sequence " + Int2StrSal( f.mData1, displayBase, 31 ) );
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_DS_SEL_ALERT_PREAMBLE ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "DS Selection Alert sequence preamble " + Int2Str( f.mData1 ) + " bits" );
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_DS_SEL_ALERT ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "DS Selection Alert sequence " + Int2StrSal( f.mData1, displayBase, 64 ) + " " + Int2StrSal( f.mData2, displayBase, 31 ) );
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE_PREAMBLE ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "DS Activation code sequence preamble " + Int2Str( f.mData1 ) + " bits" );
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                {
+                    std::string protocolName;
+                    switch( f.mData1 )
+                    {
+                    case 0x00u:
+                    case 0x0Au:
+                        protocolName = "JTAG";
+                        break;
+                    case 0x1Au:
+                        protocolName = "SWD";
+                        break;
+                    default:
+                        protocolName = "Unknown";
+                        break;
+                    }
+                    record.push_back( "DS Activation code sequence " + Int2StrSal( f.mData1, displayBase, 8 ) + " (" + protocolName + ")" );
+                }
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_OPERATION ):
+                // Skip this type of frame it will have parsed as subframes: SWD_FT_REQUEST, SWD_FT_ACK, SWD_FT_RDATA/SWD_FT_WDATA
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_REQUEST ):
+                SaveRecord( record, of );
+                record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
+                record.push_back( "Operation" );
+                record.push_back( static_cast<SWDRequestFrame&>( f ).IsRead() ? "read" : "write" );
+                record.push_back( static_cast<SWDRequestFrame&>( f ).IsAccessPort() ? "AccessPort" : "DebugPort" );
+                record.push_back( static_cast<SWDRequestFrame&>( f ).GetRegisterName() );
+                record.push_back( Int2StrSal( f.mData1, displayBase, 8 ) );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_TURNAROUND ):
+                // Skip this type of frame
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_ACK ):
+                if( f.mData1 == static_cast<U64>( SWDAcks::ACK_OK ) )
+                    record.push_back( "OK" );
+                else if( f.mData1 == static_cast<U64>( SWDAcks::ACK_WAIT ) )
+                    record.push_back( "WAIT" );
+                else if( f.mData1 == static_cast<U64>( SWDAcks::ACK_FAULT ) )
+                    record.push_back( "FAULT" );
+                else
+                    record.push_back( "<disc>" );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_WDATA ):
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_RDATA ):
+                record.push_back( Int2StrSal( f.mData1, displayBase, 32 ) );
+                {
+                    SWDRegistersUnion swdRegCouple; // Couple of previous and current SWD register
+                    swdRegCouple.blob = f.mData2;
+                    std::string regValue;
 
-            record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
-            record.push_back( "Line reset" );
-            SaveRecord( record, of );
-        }
-        else if( f.mType == SWDFT_JtagToSwd)
-        {
-            SaveRecord( record, of );
-            record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
-            record.push_back( "JTAG to SWD Sequence" );
-            SaveRecord( record, of );
-        }
-        else if( f.mType == SWDFT_Request )
-        {
-            SaveRecord( record, of );
+                    if( swdRegCouple.reg.prev == SWDRegisters::SWDR_UNDEFINED )
+                    {
+                        // DP Read except READBUFF, DP Write, AP Write
+                        regValue = GetRegisterValueDesc( swdRegCouple.reg.current, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
+                    }
+                    else
+                    {
+                        if( swdRegCouple.reg.current == SWDRegisters::SWDR_UNDEFINED )
+                        {
+                            // First AP Read
+                            regValue = "Ignored AP first read data";
+                        }
+                        else
+                        {
+                            // Next AP Reads, DP Read of READBUFF
+                            regValue = GetRegisterValueDesc( swdRegCouple.reg.prev, static_cast<U32>( f.mData1 ), displayBase, mAnalyzer->GetDPVersion() );
+                        }
+                    }
+                    record.push_back( regValue );
+                }
+                SaveRecord( record, of );
+                break;
+            case static_cast<U8>( SwdFrameTypes::SWD_FT_DATA_PARITY ):
+                // Skip this type of frame
+                break;
 
-            SWDRequestFrame& req( ( SWDRequestFrame& )f );
-            record.push_back( GetSampleTimeStr( f.mStartingSampleInclusive ) );
-            record.push_back( "Operation" );
-            record.push_back( req.IsRead() ? "read" : "write" );
-            record.push_back( req.IsAccessPort() ? "AccessPort" : "DebugPort" );
-            record.push_back( req.GetRegisterName() );
-            record.push_back( int2str_sal( req.mData1, display_base, 8 ) );
-        }
-        else if( f.mType == SWDFT_ACK )
-        {
-            if( f.mData1 == ACK_OK )
-                record.push_back( "OK" );
-            else if( f.mData1 == ACK_WAIT )
-                record.push_back( "WAIT" );
-            else if( f.mData1 == ACK_FAULT )
-                record.push_back( "FAULT" );
-            else
-                record.push_back( "<disc>" );
-        }
-        else if( (f.mType == SWDFT_WData) || (f.mType == SWDFT_RData) )
-        {
-            record.push_back( int2str_sal( f.mData1, display_base, 32 ) );
-
-            SWDRegisters reg( SWDRegisters( f.mData2 ) );
-            record.push_back( GetRegisterValueDesc( reg, U32( f.mData1 ), display_base ) );
-
-            SaveRecord( record, of );
+            default:
+                break;
         }
 
-        if( UpdateExportProgressAndCheckForCancel( fcnt, num_frames ) )
+        if( UpdateExportProgressAndCheckForCancel( fcnt, numFrames ) )
             return;
     }
 
-    UpdateExportProgressAndCheckForCancel( num_frames, num_frames );
+    UpdateExportProgressAndCheckForCancel( numFrames, numFrames );
 }
 
-void SWDAnalyzerResults::GenerateFrameTabularText( U64 frame_index, DisplayBase display_base )
+void SWDAnalyzerResults::GenerateFrameTabularText( U64 frameIndex, DisplayBase displayBase )
 {
     ClearTabularText();
 
     std::vector<std::string> results;
-    Frame f = GetFrame( frame_index );
-    GetBubbleText( f, display_base, results );
+    Frame f = GetFrame( frameIndex );
+    GetBubbleText( f, displayBase, results );
 
     if( !results.empty() )
         AddTabularText( results.front().c_str() );
 }
 
-void SWDAnalyzerResults::GeneratePacketTabularText( U64 packet_id, DisplayBase display_base )
+void SWDAnalyzerResults::GeneratePacketTabularText( U64 packetId, DisplayBase displayBase )
 {
     ClearResultStrings();
     AddResultString( "not supported" );
 }
 
-void SWDAnalyzerResults::GenerateTransactionTabularText( U64 transaction_id, DisplayBase display_base )
+void SWDAnalyzerResults::GenerateTransactionTabularText( U64 transactionId, DisplayBase displayBase )
 {
     ClearResultStrings();
     AddResultString( "not supported" );

--- a/src/SWDAnalyzerResults.h
+++ b/src/SWDAnalyzerResults.h
@@ -24,7 +24,7 @@ class SWDAnalyzerResults : public AnalyzerResults
     SWDAnalyzerSettings* GetSettings() const;
 
   protected: // functions
-    void GetBubbleText( const Frame& f, DisplayBase displayBase, std::vector<std::string>& results );
+    void GetBubbleText( const Frame& f, DisplayBase displayBase, std::vector<std::string>& results, bool onlyFirstResult );
 
   protected: // vars
     SWDAnalyzerSettings* mSettings;

--- a/src/SWDAnalyzerResults.h
+++ b/src/SWDAnalyzerResults.h
@@ -12,23 +12,19 @@ class SWDAnalyzerResults : public AnalyzerResults
     SWDAnalyzerResults( SWDAnalyzer* analyzer, SWDAnalyzerSettings* settings );
     virtual ~SWDAnalyzerResults();
 
-    virtual void GenerateBubbleText( U64 frame_index, Channel& channel, DisplayBase display_base );
-    virtual void GenerateExportFile( const char* file, DisplayBase display_base, U32 export_type_user_id );
+    virtual void GenerateBubbleText( U64 frameIndex, Channel& channel, DisplayBase displayBase ) override;
+    virtual void GenerateExportFile( const char* file, DisplayBase displayBase, U32 exportTypeUserId ) override;
 
-    virtual void GenerateFrameTabularText( U64 frame_index, DisplayBase display_base );
-    virtual void GeneratePacketTabularText( U64 packet_id, DisplayBase display_base );
-    virtual void GenerateTransactionTabularText( U64 transaction_id, DisplayBase display_base );
+    virtual void GenerateFrameTabularText( U64 frameIndex, DisplayBase displayBase ) override;
+    virtual void GeneratePacketTabularText( U64 packetId, DisplayBase displayBase ) override;
+    virtual void GenerateTransactionTabularText( U64 transactionId, DisplayBase displayBase ) override;
 
     double GetSampleTime( S64 sample ) const;
     std::string GetSampleTimeStr( S64 sample ) const;
-
-    SWDAnalyzerSettings* GetSettings()
-    {
-        return mSettings;
-    }
+    SWDAnalyzerSettings* GetSettings() const;
 
   protected: // functions
-    void GetBubbleText( const Frame& f, DisplayBase display_base, std::vector<std::string>& results );
+    void GetBubbleText( const Frame& f, DisplayBase displayBase, std::vector<std::string>& results );
 
   protected: // vars
     SWDAnalyzerSettings* mSettings;

--- a/src/SWDAnalyzerSettings.cpp
+++ b/src/SWDAnalyzerSettings.cpp
@@ -15,7 +15,7 @@ SWDAnalyzerSettings::SWDAnalyzerSettings()
       mOverrunDetection( false ),
       mSelectRegister( 0x0u )
 {
-    // init the interface
+    // Init the interface
     mSWDIOInterface.SetTitleAndTooltip( "SWDIO", "SWDIO" );
     mSWDIOInterface.SetChannel( mSWDIO );
 

--- a/src/SWDAnalyzerSettings.cpp
+++ b/src/SWDAnalyzerSettings.cpp
@@ -3,8 +3,17 @@
 #include "SWDAnalyzerSettings.h"
 #include "SWDAnalyzerResults.h"
 #include "SWDTypes.h"
+#include <sstream>
 
-SWDAnalyzerSettings::SWDAnalyzerSettings() : mSWDIO( UNDEFINED_CHANNEL ), mSWCLK( UNDEFINED_CHANNEL )
+SWDAnalyzerSettings::SWDAnalyzerSettings()
+    : mSWDIO( UNDEFINED_CHANNEL ),
+      mSWCLK( UNDEFINED_CHANNEL ),
+      mDProtocol( DebugProtocol::DPROTOCOL_UNKNOWN ),
+      mLastFrame( SwdFrameTypes::SWD_FT_LINE_RESET ),
+      mDPVersion( DPVersion::DP_V0 ),
+      mNumTurnarounds( 1u ),
+      mOverrunDetection( false ),
+      mSelectRegister( 0x0u )
 {
     // init the interface
     mSWDIOInterface.SetTitleAndTooltip( "SWDIO", "SWDIO" );
@@ -13,9 +22,53 @@ SWDAnalyzerSettings::SWDAnalyzerSettings() : mSWDIO( UNDEFINED_CHANNEL ), mSWCLK
     mSWCLKInterface.SetTitleAndTooltip( "SWCLK", "SWCLK" );
     mSWCLKInterface.SetChannel( mSWCLK );
 
+    mDProtocolInterface.SetTitleAndTooltip( "Initial protocol", "Start parsing with the assumption that the current debug protocol is" );
+    mDProtocolInterface.AddNumber( static_cast<double>( DebugProtocol::DPROTOCOL_UNKNOWN ), "Unknown", "" );
+    mDProtocolInterface.AddNumber( static_cast<double>( DebugProtocol::DPROTOCOL_DORMANT ), "Dormant", "" );
+    mDProtocolInterface.AddNumber( static_cast<double>( DebugProtocol::DPROTOCOL_JTAG ), "JTAG", "" );
+    mDProtocolInterface.AddNumber( static_cast<double>( DebugProtocol::DPROTOCOL_SWD ), "SWD", "" );
+    mDProtocolInterface.SetNumber( static_cast<double>( mDProtocol ) );
+
+    mLastFrameInterface.SetTitleAndTooltip( "Assumed previous frame", "Start parsing with the assumption that the previous frame is" );
+    for( U32 i = static_cast<U32>( SwdFrameTypes::SWD_FT_LINE_RESET ); i <= static_cast<U32>( SwdFrameTypes::SWD_FT_OPERATION ); ++i )
+    {
+        mLastFrameInterface.AddNumber( i, SWDFrame::GetSwdFrameName( static_cast<SwdFrameTypes>( i ) ).c_str(), "" );
+    }
+    mLastFrameInterface.SetNumber( static_cast<double>( mLastFrame ) );
+
+    mDPVersionInterface.SetTitleAndTooltip( "Assumed DP version", "Start parsing with the assumption that the DP version is" );
+    mDPVersionInterface.AddNumber( static_cast<double>( DPVersion::DP_V1 ), "v1", "ADIv5 ARM IHI 0031A" );
+    mDPVersionInterface.AddNumber( static_cast<double>( DPVersion::DP_V2 ), "v2", "ADIv5.2 ARM IHI 0031C" );
+    mDPVersionInterface.AddNumber( static_cast<double>( DPVersion::DP_V3 ), "v3", "ADIv6 ARM IHI 0074D" );
+    mDPVersionInterface.SetNumber( static_cast<double>( mDPVersion ) );
+
+    mNumTurnaroundsInterface.SetTitleAndTooltip( "Assumed DLCR.TURNROUND", "Start parsing with the assumption that the turnaround tristate period is" );
+    mNumTurnaroundsInterface.AddNumber( 1, "1", "1 data period" );
+    mNumTurnaroundsInterface.AddNumber( 2, "2", "2 data period" );
+    mNumTurnaroundsInterface.AddNumber( 3, "3", "3 data period" );
+    mNumTurnaroundsInterface.AddNumber( 4, "4", "4 data period" );
+    mNumTurnaroundsInterface.SetNumber( mNumTurnarounds );
+
+    mOverrunDetectionInterface.SetTitleAndTooltip( "Assumed CTRL/STAT.ORUNDETECT", "Start parsing with the assumption that the ORUNDETECT bit of DP CTRL/STAT register is" );
+    mOverrunDetectionInterface.SetValue( mOverrunDetection );
+
+    mSelectRegisterInterface.SetTitleAndTooltip( "Assumed SELECT", "Start parsing with the assumption that the SELECT register is" );
+    mSelectRegisterInterface.SetTextType( AnalyzerSettingInterfaceText::NormalText );
+    {
+        std::stringstream ss;
+        ss << "0x" << std::hex << mSelectRegister;
+        mSelectRegisterInterface.SetText( ss.str().c_str() );
+    }
+
     // add the interface
     AddInterface( &mSWDIOInterface );
     AddInterface( &mSWCLKInterface );
+    AddInterface( &mDProtocolInterface );
+    AddInterface( &mLastFrameInterface );
+    AddInterface( &mDPVersionInterface );
+    AddInterface( &mNumTurnaroundsInterface );
+    AddInterface( &mOverrunDetectionInterface );
+    AddInterface( &mSelectRegisterInterface );
 
     // describe export
     AddExportOption( 0, "Export as text file" );
@@ -59,6 +112,17 @@ bool SWDAnalyzerSettings::SetSettingsFromInterfaces()
     AddChannel( mSWDIO, "SWDIO", true );
     AddChannel( mSWCLK, "SWCLK", true );
 
+    mDProtocol = static_cast<DebugProtocol>( mDProtocolInterface.GetNumber() );
+    mLastFrame = static_cast<SwdFrameTypes>( mLastFrameInterface.GetNumber() );
+    mDPVersion = static_cast<DPVersion>( mDPVersionInterface.GetNumber() );
+    mNumTurnarounds = static_cast<U8>( mNumTurnaroundsInterface.GetNumber() );
+    mOverrunDetection = mOverrunDetectionInterface.GetValue();
+    {
+        std::stringstream ss;
+        ss << std::hex << mSelectRegisterInterface.GetText();
+        ss >> mSelectRegister;
+    }
+
     return true;
 }
 
@@ -66,15 +130,38 @@ void SWDAnalyzerSettings::UpdateInterfacesFromSettings()
 {
     mSWDIOInterface.SetChannel( mSWDIO );
     mSWCLKInterface.SetChannel( mSWCLK );
+
+    mDProtocolInterface.SetNumber( static_cast<double>( mDProtocol ) );
+    mLastFrameInterface.SetNumber( static_cast<double>( mLastFrame ) );
+    mDPVersionInterface.SetNumber( static_cast<double>( mDPVersion ) );
+    mNumTurnaroundsInterface.SetNumber( mNumTurnarounds );
+    mOverrunDetectionInterface.SetValue( mOverrunDetection );
+    {
+        std::stringstream ss;
+        ss << "0x" << std::hex << mSelectRegister;
+        mSelectRegisterInterface.SetText( ss.str().c_str() );
+    }
 }
 
 void SWDAnalyzerSettings::LoadSettings( const char* settings )
 {
-    SimpleArchive text_archive;
-    text_archive.SetString( settings );
+    SimpleArchive textArchive;
+    textArchive.SetString( settings );
 
-    text_archive >> mSWDIO;
-    text_archive >> mSWCLK;
+    textArchive >> mSWDIO;
+    textArchive >> mSWCLK;
+
+    U32 tmp;
+    textArchive >> tmp;
+    mDProtocol = static_cast<DebugProtocol>( tmp );
+    textArchive >> tmp;
+    mLastFrame = static_cast<SwdFrameTypes>( tmp );
+    textArchive >> tmp;
+    mDPVersion = static_cast<DPVersion>( tmp );
+    textArchive >> tmp;
+    mNumTurnarounds = static_cast<U8>( tmp );
+    textArchive >> mOverrunDetection;
+    textArchive >> mSelectRegister;
 
     ClearChannels();
 
@@ -86,10 +173,22 @@ void SWDAnalyzerSettings::LoadSettings( const char* settings )
 
 const char* SWDAnalyzerSettings::SaveSettings()
 {
-    SimpleArchive text_archive;
+    SimpleArchive textArchive;
 
-    text_archive << mSWDIO;
-    text_archive << mSWCLK;
+    textArchive << mSWDIO;
+    textArchive << mSWCLK;
 
-    return SetReturnString( text_archive.GetString() );
+    U32 tmp;
+    tmp = static_cast<U32>( mDProtocol );
+    textArchive << tmp;
+    tmp = static_cast<U32>( mLastFrame );
+    textArchive << tmp;
+    tmp = static_cast<U32>( mDPVersion );
+    textArchive << tmp;
+    tmp = static_cast<U32>( mNumTurnarounds );
+    textArchive << tmp;
+    textArchive << mOverrunDetection;
+    textArchive << mSelectRegister;
+
+    return SetReturnString( textArchive.GetString() );
 }

--- a/src/SWDAnalyzerSettings.h
+++ b/src/SWDAnalyzerSettings.h
@@ -12,18 +12,32 @@ class SWDAnalyzerSettings : public AnalyzerSettings
     SWDAnalyzerSettings();
     virtual ~SWDAnalyzerSettings();
 
-    virtual bool SetSettingsFromInterfaces();
-    virtual void LoadSettings( const char* settings );
-    virtual const char* SaveSettings();
+    bool SetSettingsFromInterfaces() override;
+    void LoadSettings( const char* settings ) override;
+    const char* SaveSettings() override;
 
     void UpdateInterfacesFromSettings();
 
     Channel mSWDIO;
     Channel mSWCLK;
 
+    DebugProtocol mDProtocol;
+    SwdFrameTypes mLastFrame;
+    DPVersion mDPVersion;
+    U8 mNumTurnarounds;
+    bool mOverrunDetection;
+    U32 mSelectRegister;
+
+
   protected:
     AnalyzerSettingInterfaceChannel mSWDIOInterface;
     AnalyzerSettingInterfaceChannel mSWCLKInterface;
+    AnalyzerSettingInterfaceNumberList mDProtocolInterface;
+    AnalyzerSettingInterfaceNumberList mLastFrameInterface;
+    AnalyzerSettingInterfaceNumberList mDPVersionInterface;
+    AnalyzerSettingInterfaceNumberList mNumTurnaroundsInterface;
+    AnalyzerSettingInterfaceBool mOverrunDetectionInterface;
+    AnalyzerSettingInterfaceText mSelectRegisterInterface;
 };
 
 #endif // SWD_ANALYZER_SETTINGS_H

--- a/src/SWDSimulationDataGenerator.h
+++ b/src/SWDSimulationDataGenerator.h
@@ -13,26 +13,23 @@ class SWDSimulationDataGenerator
     SWDSimulationDataGenerator();
     ~SWDSimulationDataGenerator();
 
-    void Initialize( U32 simulation_sample_rate, SWDAnalyzerSettings* settings );
-    U32 GenerateSimulationData( U64 newest_sample_requested, U32 sample_rate, SimulationChannelDescriptor** simulation_channels );
+    void Initialize( U32 simulationSampleRate, SWDAnalyzerSettings* settings );
+    U32 GenerateSimulationData( U64 newestSampleRequested, U32 sampleRate, SimulationChannelDescriptor** simulationChannels );
 
   protected:
     SWDAnalyzerSettings* mSettings;
     U32 mSimulationSampleRateHz;
     U32 mSimulCnt;
 
-    void AdvanceAllBySec( double sec )
-    {
-        mSWDSimulationChannels.AdvanceAll( mClockGenerator.AdvanceByTimeS( sec ) );
-    }
+    void AdvanceAllBySec( double sec );
 
     // read and write in this context is a bit read or written from the perspective of the host
     void OutputWriteBit( BitState state );
-    void OutputReadBit( BitState first_half, BitState second_half );
+    void OutputReadBit( BitState firstHalf, BitState secondHalf );
 
     void OutputTurnaround( BitState state );
-    bool OutputRequest( U8 req, U8 ack, BitState first_data_bit );
-    void OutputData( U32 data, bool is_write );
+    bool OutputRequest( U8 req, U8 ack, BitState firstDataBit );
+    void OutputData( U32 data, bool isWrite );
     void OutputLineReset();
 
   protected:

--- a/src/SWDTypes.cpp
+++ b/src/SWDTypes.cpp
@@ -10,15 +10,419 @@
 #include "SWDTypes.h"
 #include "SWDUtils.h"
 
-const int TRAN_REQ_AND_ACK = 8 + 1 + 3;             // request/turnaround/ACK
-const int TRAN_READ_LENGTH = TRAN_REQ_AND_ACK + 33; // previous + 32bit data + parity
-const int TRAN_WRITE_LENGTH = TRAN_READ_LENGTH + 1; // previous + one bit for turnaround
-const int TRAN_JTAG_TO_SWD = 16;
+// DP registers
+
+enum class DPMask : U8      // Access and version bit field
+{
+    DP_REG_READ  = 0b00001u,
+    DP_REG_WRITE = 0b00010u,
+    DP_REG_V1    = 0b00100u,
+    DP_REG_V2    = 0b01000u,
+    DP_REG_V3    = 0b10000u
+};
+U8 operator|( const DPMask a, const DPMask b )
+{
+    return ( static_cast<U8>( a ) | static_cast<U8>( b ) );
+}
+U8 operator|( const U8 a, const DPMask b )
+{
+    return ( a | static_cast<U8>( b ) );
+}
+
+const std::map<U8, std::vector<SWDOperation::DPRegister>> SWDOperation::DP_REGISTERS = {
+    { 0x00u,
+        {
+            { {}, DPMask::DP_REG_READ | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 , SWDRegisters::SWDR_DP_DPIDR },
+            { { 0x00u }, DPMask::DP_REG_READ | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_DPIDR },
+            { { 0x01u }, DPMask::DP_REG_READ | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_DPIDR1 },
+            { { 0x02u }, DPMask::DP_REG_READ | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_BASEPTR0 },
+            { { 0x03u }, DPMask::DP_REG_READ | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_BASEPTR1 },
+            { {}, DPMask::DP_REG_WRITE | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_ABORT }
+        }
+    },
+    { 0x04u,
+        {
+            { { 0x00u }, DPMask::DP_REG_READ | DPMask::DP_REG_WRITE | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_CTRL_STAT },
+            { { 0x01u }, DPMask::DP_REG_READ | DPMask::DP_REG_WRITE | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_DLCR },
+            { { 0x02u }, DPMask::DP_REG_READ | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_TARGETID },
+            { { 0x03u }, DPMask::DP_REG_READ | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_DLPIDR },
+            { { 0x04u }, DPMask::DP_REG_READ | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_EVENTSTAT },
+            { { 0x05u }, DPMask::DP_REG_WRITE | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_SELECT1 },
+        }
+    },
+    { 0x08u,
+        {
+            { {}, DPMask::DP_REG_READ | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_RESEND },
+            { {}, DPMask::DP_REG_WRITE | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_SELECT }
+        }
+    },
+    { 0x0Cu,
+        {
+            { {}, DPMask::DP_REG_READ | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_RDBUFF },
+            { {}, DPMask::DP_REG_WRITE | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_TARGETSEL }
+        }
+    },
+};
+
+const std::map<U8, SWDRegisters> SWDOperation::MEM_AP_ADI_V5 = {
+    { 0x00u, SWDRegisters::SWDR_AP_CSW },
+    { 0x04u, SWDRegisters::SWDR_AP_TAR },
+    { 0x08u, SWDRegisters::SWDR_AP_TAR_MSW },
+    { 0x0Cu, SWDRegisters::SWDR_AP_DRW },
+    { 0x10u, SWDRegisters::SWDR_AP_BD0 },
+    { 0x14u, SWDRegisters::SWDR_AP_BD1 },
+    { 0x18u, SWDRegisters::SWDR_AP_BD2 },
+    { 0x1Cu, SWDRegisters::SWDR_AP_BD3 },
+    { 0x20u, SWDRegisters::SWDR_AP_MBT },
+    { 0xF0u, SWDRegisters::SWDR_AP_BASE_MSW },
+    { 0xF4u, SWDRegisters::SWDR_AP_CFG },
+    { 0xF8u, SWDRegisters::SWDR_AP_BASE },
+    { 0xFCu, SWDRegisters::SWDR_AP_IDR }
+};
+
+const std::map<U16, SWDRegisters> SWDOperation::MEM_AP_ADI_V6 = {
+    { 0x000u, SWDRegisters::SWDR_AP_DAR0 },
+    { 0x004u, SWDRegisters::SWDR_AP_DAR1 },
+    { 0x008u, SWDRegisters::SWDR_AP_DAR2 },
+    { 0x00Cu, SWDRegisters::SWDR_AP_DAR3 },
+    { 0x010u, SWDRegisters::SWDR_AP_DAR4 },
+    { 0x014u, SWDRegisters::SWDR_AP_DAR5 },
+    { 0x018u, SWDRegisters::SWDR_AP_DAR6 },
+    { 0x01Cu, SWDRegisters::SWDR_AP_DAR7 },
+    { 0x020u, SWDRegisters::SWDR_AP_DAR8 },
+    { 0x024u, SWDRegisters::SWDR_AP_DAR9 },
+    { 0x028u, SWDRegisters::SWDR_AP_DAR10 },
+    { 0x02Cu, SWDRegisters::SWDR_AP_DAR11 },
+    { 0x030u, SWDRegisters::SWDR_AP_DAR12 },
+    { 0x034u, SWDRegisters::SWDR_AP_DAR13 },
+    { 0x038u, SWDRegisters::SWDR_AP_DAR14 },
+    { 0x03Cu, SWDRegisters::SWDR_AP_DAR15 },
+    { 0x040u, SWDRegisters::SWDR_AP_DAR16 },
+    { 0x044u, SWDRegisters::SWDR_AP_DAR17 },
+    { 0x048u, SWDRegisters::SWDR_AP_DAR18 },
+    { 0x04Cu, SWDRegisters::SWDR_AP_DAR19 },
+    { 0x050u, SWDRegisters::SWDR_AP_DAR20 },
+    { 0x054u, SWDRegisters::SWDR_AP_DAR21 },
+    { 0x058u, SWDRegisters::SWDR_AP_DAR22 },
+    { 0x05Cu, SWDRegisters::SWDR_AP_DAR23 },
+    { 0x060u, SWDRegisters::SWDR_AP_DAR24 },
+    { 0x064u, SWDRegisters::SWDR_AP_DAR25 },
+    { 0x068u, SWDRegisters::SWDR_AP_DAR26 },
+    { 0x06Cu, SWDRegisters::SWDR_AP_DAR27 },
+    { 0x070u, SWDRegisters::SWDR_AP_DAR28 },
+    { 0x074u, SWDRegisters::SWDR_AP_DAR29 },
+    { 0x078u, SWDRegisters::SWDR_AP_DAR30 },
+    { 0x07Cu, SWDRegisters::SWDR_AP_DAR31 },
+    { 0x080u, SWDRegisters::SWDR_AP_DAR32 },
+    { 0x084u, SWDRegisters::SWDR_AP_DAR33 },
+    { 0x088u, SWDRegisters::SWDR_AP_DAR34 },
+    { 0x08Cu, SWDRegisters::SWDR_AP_DAR35 },
+    { 0x090u, SWDRegisters::SWDR_AP_DAR36 },
+    { 0x094u, SWDRegisters::SWDR_AP_DAR37 },
+    { 0x098u, SWDRegisters::SWDR_AP_DAR38 },
+    { 0x09Cu, SWDRegisters::SWDR_AP_DAR39 },
+    { 0x0A0u, SWDRegisters::SWDR_AP_DAR40 },
+    { 0x0A4u, SWDRegisters::SWDR_AP_DAR41 },
+    { 0x0A8u, SWDRegisters::SWDR_AP_DAR42 },
+    { 0x0ACu, SWDRegisters::SWDR_AP_DAR43 },
+    { 0x0B0u, SWDRegisters::SWDR_AP_DAR44 },
+    { 0x0B4u, SWDRegisters::SWDR_AP_DAR45 },
+    { 0x0B8u, SWDRegisters::SWDR_AP_DAR46 },
+    { 0x0BCu, SWDRegisters::SWDR_AP_DAR47 },
+    { 0x0C0u, SWDRegisters::SWDR_AP_DAR48 },
+    { 0x0C4u, SWDRegisters::SWDR_AP_DAR49 },
+    { 0x0C8u, SWDRegisters::SWDR_AP_DAR50 },
+    { 0x0CCu, SWDRegisters::SWDR_AP_DAR51 },
+    { 0x0D0u, SWDRegisters::SWDR_AP_DAR52 },
+    { 0x0D4u, SWDRegisters::SWDR_AP_DAR53 },
+    { 0x0D8u, SWDRegisters::SWDR_AP_DAR54 },
+    { 0x0DCu, SWDRegisters::SWDR_AP_DAR55 },
+    { 0x0E0u, SWDRegisters::SWDR_AP_DAR56 },
+    { 0x0E4u, SWDRegisters::SWDR_AP_DAR57 },
+    { 0x0E8u, SWDRegisters::SWDR_AP_DAR58 },
+    { 0x0ECu, SWDRegisters::SWDR_AP_DAR59 },
+    { 0x0F0u, SWDRegisters::SWDR_AP_DAR60 },
+    { 0x0F4u, SWDRegisters::SWDR_AP_DAR61 },
+    { 0x0F8u, SWDRegisters::SWDR_AP_DAR62 },
+    { 0x0FCu, SWDRegisters::SWDR_AP_DAR63 },
+    { 0x100u, SWDRegisters::SWDR_AP_DAR64 },
+    { 0x104u, SWDRegisters::SWDR_AP_DAR65 },
+    { 0x108u, SWDRegisters::SWDR_AP_DAR66 },
+    { 0x10Cu, SWDRegisters::SWDR_AP_DAR67 },
+    { 0x110u, SWDRegisters::SWDR_AP_DAR68 },
+    { 0x114u, SWDRegisters::SWDR_AP_DAR69 },
+    { 0x118u, SWDRegisters::SWDR_AP_DAR70 },
+    { 0x11Cu, SWDRegisters::SWDR_AP_DAR71 },
+    { 0x120u, SWDRegisters::SWDR_AP_DAR72 },
+    { 0x124u, SWDRegisters::SWDR_AP_DAR73 },
+    { 0x128u, SWDRegisters::SWDR_AP_DAR74 },
+    { 0x12Cu, SWDRegisters::SWDR_AP_DAR75 },
+    { 0x130u, SWDRegisters::SWDR_AP_DAR76 },
+    { 0x134u, SWDRegisters::SWDR_AP_DAR77 },
+    { 0x138u, SWDRegisters::SWDR_AP_DAR78 },
+    { 0x13Cu, SWDRegisters::SWDR_AP_DAR79 },
+    { 0x140u, SWDRegisters::SWDR_AP_DAR80 },
+    { 0x144u, SWDRegisters::SWDR_AP_DAR81 },
+    { 0x148u, SWDRegisters::SWDR_AP_DAR82 },
+    { 0x14Cu, SWDRegisters::SWDR_AP_DAR83 },
+    { 0x150u, SWDRegisters::SWDR_AP_DAR84 },
+    { 0x154u, SWDRegisters::SWDR_AP_DAR85 },
+    { 0x158u, SWDRegisters::SWDR_AP_DAR86 },
+    { 0x15Cu, SWDRegisters::SWDR_AP_DAR87 },
+    { 0x160u, SWDRegisters::SWDR_AP_DAR88 },
+    { 0x164u, SWDRegisters::SWDR_AP_DAR89 },
+    { 0x168u, SWDRegisters::SWDR_AP_DAR90 },
+    { 0x16Cu, SWDRegisters::SWDR_AP_DAR91 },
+    { 0x170u, SWDRegisters::SWDR_AP_DAR92 },
+    { 0x174u, SWDRegisters::SWDR_AP_DAR93 },
+    { 0x178u, SWDRegisters::SWDR_AP_DAR94 },
+    { 0x17Cu, SWDRegisters::SWDR_AP_DAR95 },
+    { 0x180u, SWDRegisters::SWDR_AP_DAR96 },
+    { 0x184u, SWDRegisters::SWDR_AP_DAR97 },
+    { 0x188u, SWDRegisters::SWDR_AP_DAR98 },
+    { 0x18Cu, SWDRegisters::SWDR_AP_DAR99 },
+    { 0x190u, SWDRegisters::SWDR_AP_DAR100 },
+    { 0x194u, SWDRegisters::SWDR_AP_DAR101 },
+    { 0x198u, SWDRegisters::SWDR_AP_DAR102 },
+    { 0x19Cu, SWDRegisters::SWDR_AP_DAR103 },
+    { 0x1A0u, SWDRegisters::SWDR_AP_DAR104 },
+    { 0x1A4u, SWDRegisters::SWDR_AP_DAR105 },
+    { 0x1A8u, SWDRegisters::SWDR_AP_DAR106 },
+    { 0x1ACu, SWDRegisters::SWDR_AP_DAR107 },
+    { 0x1B0u, SWDRegisters::SWDR_AP_DAR108 },
+    { 0x1B4u, SWDRegisters::SWDR_AP_DAR109 },
+    { 0x1B8u, SWDRegisters::SWDR_AP_DAR110 },
+    { 0x1BCu, SWDRegisters::SWDR_AP_DAR111 },
+    { 0x1C0u, SWDRegisters::SWDR_AP_DAR112 },
+    { 0x1C4u, SWDRegisters::SWDR_AP_DAR113 },
+    { 0x1C8u, SWDRegisters::SWDR_AP_DAR114 },
+    { 0x1CCu, SWDRegisters::SWDR_AP_DAR115 },
+    { 0x1D0u, SWDRegisters::SWDR_AP_DAR116 },
+    { 0x1D4u, SWDRegisters::SWDR_AP_DAR117 },
+    { 0x1D8u, SWDRegisters::SWDR_AP_DAR118 },
+    { 0x1DCu, SWDRegisters::SWDR_AP_DAR119 },
+    { 0x1E0u, SWDRegisters::SWDR_AP_DAR120 },
+    { 0x1E4u, SWDRegisters::SWDR_AP_DAR121 },
+    { 0x1E8u, SWDRegisters::SWDR_AP_DAR122 },
+    { 0x1ECu, SWDRegisters::SWDR_AP_DAR123 },
+    { 0x1F0u, SWDRegisters::SWDR_AP_DAR124 },
+    { 0x1F4u, SWDRegisters::SWDR_AP_DAR125 },
+    { 0x1F8u, SWDRegisters::SWDR_AP_DAR126 },
+    { 0x1FCu, SWDRegisters::SWDR_AP_DAR127 },
+    { 0x200u, SWDRegisters::SWDR_AP_DAR128 },
+    { 0x204u, SWDRegisters::SWDR_AP_DAR129 },
+    { 0x208u, SWDRegisters::SWDR_AP_DAR130 },
+    { 0x20Cu, SWDRegisters::SWDR_AP_DAR131 },
+    { 0x210u, SWDRegisters::SWDR_AP_DAR132 },
+    { 0x214u, SWDRegisters::SWDR_AP_DAR133 },
+    { 0x218u, SWDRegisters::SWDR_AP_DAR134 },
+    { 0x21Cu, SWDRegisters::SWDR_AP_DAR135 },
+    { 0x220u, SWDRegisters::SWDR_AP_DAR136 },
+    { 0x224u, SWDRegisters::SWDR_AP_DAR137 },
+    { 0x228u, SWDRegisters::SWDR_AP_DAR138 },
+    { 0x22Cu, SWDRegisters::SWDR_AP_DAR139 },
+    { 0x230u, SWDRegisters::SWDR_AP_DAR140 },
+    { 0x234u, SWDRegisters::SWDR_AP_DAR141 },
+    { 0x238u, SWDRegisters::SWDR_AP_DAR142 },
+    { 0x23Cu, SWDRegisters::SWDR_AP_DAR143 },
+    { 0x240u, SWDRegisters::SWDR_AP_DAR144 },
+    { 0x244u, SWDRegisters::SWDR_AP_DAR145 },
+    { 0x248u, SWDRegisters::SWDR_AP_DAR146 },
+    { 0x24Cu, SWDRegisters::SWDR_AP_DAR147 },
+    { 0x250u, SWDRegisters::SWDR_AP_DAR148 },
+    { 0x254u, SWDRegisters::SWDR_AP_DAR149 },
+    { 0x258u, SWDRegisters::SWDR_AP_DAR150 },
+    { 0x25Cu, SWDRegisters::SWDR_AP_DAR151 },
+    { 0x260u, SWDRegisters::SWDR_AP_DAR152 },
+    { 0x264u, SWDRegisters::SWDR_AP_DAR153 },
+    { 0x268u, SWDRegisters::SWDR_AP_DAR154 },
+    { 0x26Cu, SWDRegisters::SWDR_AP_DAR155 },
+    { 0x270u, SWDRegisters::SWDR_AP_DAR156 },
+    { 0x274u, SWDRegisters::SWDR_AP_DAR157 },
+    { 0x278u, SWDRegisters::SWDR_AP_DAR158 },
+    { 0x27Cu, SWDRegisters::SWDR_AP_DAR159 },
+    { 0x280u, SWDRegisters::SWDR_AP_DAR160 },
+    { 0x284u, SWDRegisters::SWDR_AP_DAR161 },
+    { 0x288u, SWDRegisters::SWDR_AP_DAR162 },
+    { 0x28Cu, SWDRegisters::SWDR_AP_DAR163 },
+    { 0x290u, SWDRegisters::SWDR_AP_DAR164 },
+    { 0x294u, SWDRegisters::SWDR_AP_DAR165 },
+    { 0x298u, SWDRegisters::SWDR_AP_DAR166 },
+    { 0x29Cu, SWDRegisters::SWDR_AP_DAR167 },
+    { 0x2A0u, SWDRegisters::SWDR_AP_DAR168 },
+    { 0x2A4u, SWDRegisters::SWDR_AP_DAR169 },
+    { 0x2A8u, SWDRegisters::SWDR_AP_DAR170 },
+    { 0x2ACu, SWDRegisters::SWDR_AP_DAR171 },
+    { 0x2B0u, SWDRegisters::SWDR_AP_DAR172 },
+    { 0x2B4u, SWDRegisters::SWDR_AP_DAR173 },
+    { 0x2B8u, SWDRegisters::SWDR_AP_DAR174 },
+    { 0x2BCu, SWDRegisters::SWDR_AP_DAR175 },
+    { 0x2C0u, SWDRegisters::SWDR_AP_DAR176 },
+    { 0x2C4u, SWDRegisters::SWDR_AP_DAR177 },
+    { 0x2C8u, SWDRegisters::SWDR_AP_DAR178 },
+    { 0x2CCu, SWDRegisters::SWDR_AP_DAR179 },
+    { 0x2D0u, SWDRegisters::SWDR_AP_DAR180 },
+    { 0x2D4u, SWDRegisters::SWDR_AP_DAR181 },
+    { 0x2D8u, SWDRegisters::SWDR_AP_DAR182 },
+    { 0x2DCu, SWDRegisters::SWDR_AP_DAR183 },
+    { 0x2E0u, SWDRegisters::SWDR_AP_DAR184 },
+    { 0x2E4u, SWDRegisters::SWDR_AP_DAR185 },
+    { 0x2E8u, SWDRegisters::SWDR_AP_DAR186 },
+    { 0x2ECu, SWDRegisters::SWDR_AP_DAR187 },
+    { 0x2F0u, SWDRegisters::SWDR_AP_DAR188 },
+    { 0x2F4u, SWDRegisters::SWDR_AP_DAR189 },
+    { 0x2F8u, SWDRegisters::SWDR_AP_DAR190 },
+    { 0x2FCu, SWDRegisters::SWDR_AP_DAR191 },
+    { 0x300u, SWDRegisters::SWDR_AP_DAR192 },
+    { 0x304u, SWDRegisters::SWDR_AP_DAR193 },
+    { 0x308u, SWDRegisters::SWDR_AP_DAR194 },
+    { 0x30Cu, SWDRegisters::SWDR_AP_DAR195 },
+    { 0x310u, SWDRegisters::SWDR_AP_DAR196 },
+    { 0x314u, SWDRegisters::SWDR_AP_DAR197 },
+    { 0x318u, SWDRegisters::SWDR_AP_DAR198 },
+    { 0x31Cu, SWDRegisters::SWDR_AP_DAR199 },
+    { 0x320u, SWDRegisters::SWDR_AP_DAR200 },
+    { 0x324u, SWDRegisters::SWDR_AP_DAR201 },
+    { 0x328u, SWDRegisters::SWDR_AP_DAR202 },
+    { 0x32Cu, SWDRegisters::SWDR_AP_DAR203 },
+    { 0x330u, SWDRegisters::SWDR_AP_DAR204 },
+    { 0x334u, SWDRegisters::SWDR_AP_DAR205 },
+    { 0x338u, SWDRegisters::SWDR_AP_DAR206 },
+    { 0x33Cu, SWDRegisters::SWDR_AP_DAR207 },
+    { 0x340u, SWDRegisters::SWDR_AP_DAR208 },
+    { 0x344u, SWDRegisters::SWDR_AP_DAR209 },
+    { 0x348u, SWDRegisters::SWDR_AP_DAR210 },
+    { 0x34Cu, SWDRegisters::SWDR_AP_DAR211 },
+    { 0x350u, SWDRegisters::SWDR_AP_DAR212 },
+    { 0x354u, SWDRegisters::SWDR_AP_DAR213 },
+    { 0x358u, SWDRegisters::SWDR_AP_DAR214 },
+    { 0x35Cu, SWDRegisters::SWDR_AP_DAR215 },
+    { 0x360u, SWDRegisters::SWDR_AP_DAR216 },
+    { 0x364u, SWDRegisters::SWDR_AP_DAR217 },
+    { 0x368u, SWDRegisters::SWDR_AP_DAR218 },
+    { 0x36Cu, SWDRegisters::SWDR_AP_DAR219 },
+    { 0x370u, SWDRegisters::SWDR_AP_DAR220 },
+    { 0x374u, SWDRegisters::SWDR_AP_DAR221 },
+    { 0x378u, SWDRegisters::SWDR_AP_DAR222 },
+    { 0x37Cu, SWDRegisters::SWDR_AP_DAR223 },
+    { 0x380u, SWDRegisters::SWDR_AP_DAR224 },
+    { 0x384u, SWDRegisters::SWDR_AP_DAR225 },
+    { 0x388u, SWDRegisters::SWDR_AP_DAR226 },
+    { 0x38Cu, SWDRegisters::SWDR_AP_DAR227 },
+    { 0x390u, SWDRegisters::SWDR_AP_DAR228 },
+    { 0x394u, SWDRegisters::SWDR_AP_DAR229 },
+    { 0x398u, SWDRegisters::SWDR_AP_DAR230 },
+    { 0x39Cu, SWDRegisters::SWDR_AP_DAR231 },
+    { 0x3A0u, SWDRegisters::SWDR_AP_DAR232 },
+    { 0x3A4u, SWDRegisters::SWDR_AP_DAR233 },
+    { 0x3A8u, SWDRegisters::SWDR_AP_DAR234 },
+    { 0x3ACu, SWDRegisters::SWDR_AP_DAR235 },
+    { 0x3B0u, SWDRegisters::SWDR_AP_DAR236 },
+    { 0x3B4u, SWDRegisters::SWDR_AP_DAR237 },
+    { 0x3B8u, SWDRegisters::SWDR_AP_DAR238 },
+    { 0x3BCu, SWDRegisters::SWDR_AP_DAR239 },
+    { 0x3C0u, SWDRegisters::SWDR_AP_DAR240 },
+    { 0x3C4u, SWDRegisters::SWDR_AP_DAR241 },
+    { 0x3C8u, SWDRegisters::SWDR_AP_DAR242 },
+    { 0x3CCu, SWDRegisters::SWDR_AP_DAR243 },
+    { 0x3D0u, SWDRegisters::SWDR_AP_DAR244 },
+    { 0x3D4u, SWDRegisters::SWDR_AP_DAR245 },
+    { 0x3D8u, SWDRegisters::SWDR_AP_DAR246 },
+    { 0x3DCu, SWDRegisters::SWDR_AP_DAR247 },
+    { 0x3E0u, SWDRegisters::SWDR_AP_DAR248 },
+    { 0x3E4u, SWDRegisters::SWDR_AP_DAR249 },
+    { 0x3E8u, SWDRegisters::SWDR_AP_DAR250 },
+    { 0x3ECu, SWDRegisters::SWDR_AP_DAR251 },
+    { 0x3F0u, SWDRegisters::SWDR_AP_DAR252 },
+    { 0x3F4u, SWDRegisters::SWDR_AP_DAR253 },
+    { 0x3F8u, SWDRegisters::SWDR_AP_DAR254 },
+    { 0x3FCu, SWDRegisters::SWDR_AP_DAR255 },
+
+    { 0xD00u, SWDRegisters::SWDR_AP_CSW },
+    { 0xD04u, SWDRegisters::SWDR_AP_TAR },
+    { 0xD08u, SWDRegisters::SWDR_AP_TAR_MSW },
+    { 0xD0Cu, SWDRegisters::SWDR_AP_DRW },
+    { 0xD10u, SWDRegisters::SWDR_AP_BD0 },
+    { 0xD14u, SWDRegisters::SWDR_AP_BD1 },
+    { 0xD18u, SWDRegisters::SWDR_AP_BD2 },
+    { 0xD1Cu, SWDRegisters::SWDR_AP_BD3 },
+    { 0xD20u, SWDRegisters::SWDR_AP_MBT },
+    { 0xD24u, SWDRegisters::SWDR_AP_TRR },
+    { 0xD30u, SWDRegisters::SWDR_AP_T0TR },
+    { 0xDE0u, SWDRegisters::SWDR_AP_CFG1 },
+    { 0xDF0u, SWDRegisters::SWDR_AP_BASE_MSW },
+    { 0xDF4u, SWDRegisters::SWDR_AP_CFG },
+    { 0xDF8u, SWDRegisters::SWDR_AP_BASE },
+    { 0xDFCu, SWDRegisters::SWDR_AP_IDR },
+    { 0xF00u, SWDRegisters::SWDR_AP_ITCTRL },
+    { 0xFA0u, SWDRegisters::SWDR_AP_CLAIMSET },
+    { 0xFA4u, SWDRegisters::SWDR_AP_CLAIMCLR },
+    { 0xFA8u, SWDRegisters::SWDR_AP_DEVAFF0 },
+    { 0xFACu, SWDRegisters::SWDR_AP_DEVAFF1 },
+    { 0xFB0u, SWDRegisters::SWDR_AP_LAR },
+    { 0xFB4u, SWDRegisters::SWDR_AP_LSR },
+    { 0xFB8u, SWDRegisters::SWDR_AP_AUTHSTATUS },
+    { 0xFBCu, SWDRegisters::SWDR_AP_DEVARCH },
+    { 0xFC0u, SWDRegisters::SWDR_AP_DEVID2 },
+    { 0xFC4u, SWDRegisters::SWDR_AP_DEVID1 },
+    { 0xFC8u, SWDRegisters::SWDR_AP_DEVID },
+    { 0xFCCu, SWDRegisters::SWDR_AP_DEVTYPE },
+    { 0xFD0u, SWDRegisters::SWDR_AP_PIDR4 },
+    { 0xFD4u, SWDRegisters::SWDR_AP_PIDR5 },
+    { 0xFD8u, SWDRegisters::SWDR_AP_PIDR6 },
+    { 0xFDCu, SWDRegisters::SWDR_AP_PIDR7 },
+    { 0xFE0u, SWDRegisters::SWDR_AP_PIDR0 },
+    { 0xFE4u, SWDRegisters::SWDR_AP_PIDR1 },
+    { 0xFE8u, SWDRegisters::SWDR_AP_PIDR2 },
+    { 0xFECu, SWDRegisters::SWDR_AP_PIDR3 },
+    { 0xFF0u, SWDRegisters::SWDR_AP_CIDR0 },
+    { 0xFF4u, SWDRegisters::SWDR_AP_CIDR1 },
+    { 0xFF8u, SWDRegisters::SWDR_AP_CIDR2 },
+    { 0xFFCu, SWDRegisters::SWDR_AP_CIDR3 }
+};
+
+const std::map<SwdFrameTypes, std::string> SWDFrame::FRAME_NAMES =
+{
+    { SwdFrameTypes::SWD_FT_ERROR, "Erroneus bits" },
+    { SwdFrameTypes::SWD_FT_IGNORED, "Ignored bits" },
+    { SwdFrameTypes::SWD_FT_LINE_RESET, "SWD Line Reset" },
+    { SwdFrameTypes::SWD_FT_JTAG_TO_SWD, "JTAG to SWD" },
+    { SwdFrameTypes::SWD_FT_SWD_TO_JTAG, "SWD to JTAG" },
+    { SwdFrameTypes::SWD_FT_IDLE_CYCLE, "SWD Idle Cycles" },
+    { SwdFrameTypes::SWD_FT_JTAG_TLR, "JTAG Test-Logic-Reset" },
+    { SwdFrameTypes::SWD_FT_JTAG_TO_DS, "JTAG to DS sequence" },
+    { SwdFrameTypes::SWD_FT_SWD_TO_DS, "SWD to DS sequence" },
+    { SwdFrameTypes::SWD_FT_DS_SEL_ALERT_PREAMBLE, "DS Selection Alert sequence preamble" },
+    { SwdFrameTypes::SWD_FT_DS_SEL_ALERT, "DS Selection Alert sequence" },
+    { SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE_PREAMBLE, "DS Activation code sequence preamble" },
+    { SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE, "DS Activation code sequence" },
+    { SwdFrameTypes::SWD_FT_OPERATION, "SWD Transfer" }
+};
+
+const std::string SWDFrame::GetSwdFrameName( SwdFrameTypes frame )
+{
+    auto search = FRAME_NAMES.find( frame );
+    if( search != FRAME_NAMES.end() )
+    {
+        return search->second;
+    }
+    else
+    {
+        return "Unknown frame";
+    }
+}
+
+// ********************************************************************************
+
+bool SWDBit::IsHigh( bool isRising ) const
+{
+    return ( isRising ? stateRising : stateFalling ) == BIT_HIGH;
+}
 
 S64 SWDBit::GetMinStartEnd() const
 {
-    S64 s = ( rising - low_start ) / 2;
-    S64 e = ( low_end - falling ) / 2;
+    S64 s = ( rising - lowStart ) / 2;
+    S64 e = ( lowEnd - falling ) / 2;
     return s < e ? s : e;
 }
 
@@ -32,22 +436,577 @@ S64 SWDBit::GetEndSample() const
     return falling + GetMinStartEnd() - 1;
 }
 
-Frame SWDBit::MakeFrame()
+Frame SWDBit::MakeFrame() const
 {
     Frame f;
 
-    f.mType = SWDFT_Bit;
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_BIT );
     f.mFlags = 0;
     f.mStartingSampleInclusive = GetStartSample();
     f.mEndingSampleInclusive = GetEndSample();
 
-    f.mData1 = state_rising == BIT_HIGH ? 1 : 0;
+    f.mData1 = stateRising == BIT_HIGH ? 1 : 0;
     f.mData2 = 0;
 
     return f;
 }
 
 // ********************************************************************************
+
+SWDRequestByte::SWDRequestByte( const U8 byteValue )
+{
+    byte = byteValue;
+}
+
+bool SWDRequestByte::IsByteValid() const
+{
+    // List of valid SWD request bytes
+    static std::set<U8> allowedValues = { 0x81u, 0x87u, 0x8Bu, 0x8Du, 0x93u, 0x95u, 0x99u, 0x9Fu,
+                                          0xA3u, 0xA5u, 0xA9u, 0xAFu, 0xB1u, 0xB7u, 0xBBu, 0xBDu };
+
+    return allowedValues.find( byte ) != allowedValues.end();
+}
+
+bool SWDRequestByte::GetAPnDP() const
+{
+    return ( byte & 0x02u ) != 0u;
+}
+
+bool SWDRequestByte::GetRnW() const
+{
+    return ( byte & 0x04u ) != 0u;
+}
+
+U8 SWDRequestByte::GetAddr() const
+{
+    return ( byte & 0x18u ) >> 1u;
+}
+
+// ********************************************************************************
+
+void SWDBaseSequnce::Clear()
+{
+    bits.clear();
+}
+
+void SWDBaseSequnce::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+}
+
+void SWDBaseSequnce::AddMarkers( SWDAnalyzerResults* pResults ) const
+{
+}
+
+// ********************************************************************************
+
+void SWDOperation::Clear()
+{
+    reqRnW = reqAPnDP = parityRead = dataParityOk = false;
+    addr = parityRead = requestByte = reqAck = dataParity = data = 0;
+    reg = SWDRegisters::SWDR_UNDEFINED;
+
+    bits.clear();
+}
+
+void SWDOperation::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    static size_t numApReads = 0;
+    static SWDRegisters lastRegister = SWDRegisters::SWDR_UNDEFINED;
+
+    Frame f;
+
+    assert( bits.size() >= 8u + GetTurnaroundNumber() + 3u );
+
+    // request
+    SWDRequestFrame req;
+    req.mStartingSampleInclusive = bits[ 0u ].GetStartSample();
+    req.mEndingSampleInclusive = bits[ 7u ].GetEndSample();
+    req.mFlags = ( IsRead() ? SWDRequestFrame::IS_READ : 0u ) | ( reqAPnDP ? SWDRequestFrame::IS_ACCESS_PORT : 0u );
+    req.SetRequestByte( requestByte );
+    req.SetRegister( reg );
+    req.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_REQUEST );
+    pResults->AddFrame( req );
+
+    std::deque<SWDBit>::const_iterator bi( bits.begin() + 8u );
+    // turnaround
+    f = bi->MakeFrame();
+    f.mEndingSampleInclusive = bi[ GetTurnaroundNumber() - 1u ].GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_TURNAROUND );
+    pResults->AddFrame( f );
+    bi += GetTurnaroundNumber();
+
+    // ack
+    f = bi->MakeFrame();
+    f.mEndingSampleInclusive = bi[ 2u ].GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_ACK );
+    f.mData1 = reqAck;
+    pResults->AddFrame( f );
+    bi += 3u;
+
+    // turnaround if ACK is WAIT or FAULT or OK with write operation
+    if( ( reqAck == static_cast<U8>( SWDAcks::ACK_WAIT ) ) ||
+        ( reqAck == static_cast<U8>( SWDAcks::ACK_FAULT ) ) ||
+        ( ( reqAck == static_cast<U8>( SWDAcks::ACK_OK ) ) && !IsRead() ) )
+    {
+        f = bi->MakeFrame();
+        f.mEndingSampleInclusive = bi[ GetTurnaroundNumber() - 1u ].GetEndSample();
+        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_TURNAROUND );
+        pResults->AddFrame( f );
+        bi += GetTurnaroundNumber();
+    }
+    if( bits.size() < 8u + GetTurnaroundNumber() + 3u + 32u + 1u + GetTurnaroundNumber() )
+        return;
+
+    // data
+    f = bi->MakeFrame();
+    f.mEndingSampleInclusive = bi[ 31u ].GetEndSample();
+    if( IsRead() )
+    {
+        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_RDATA );
+    }
+    else
+    {
+        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_WDATA );
+    }
+
+    SWDRegistersUnion swdRegCouple; // Couple of previous and current SWD register
+    if( IsRead() )
+    {
+        if( reqAPnDP )
+        {
+            // AP read
+            if( numApReads == 0 )
+            {
+                // On the first AP read access, the read data that is returned is unknown. The debugger must discard this result.
+                swdRegCouple.reg.prev = reg;
+                swdRegCouple.reg.current = SWDRegisters::SWDR_UNDEFINED;
+            }
+            else
+            {
+                // The next AP read access, if successful, returns the result of the previous AP read.
+                swdRegCouple.reg.prev = lastRegister;
+                swdRegCouple.reg.current = reg;
+            }
+            numApReads++;
+            lastRegister = reg;
+        }
+        else
+        {
+            // DP read
+            if( ( numApReads != 0 ) && ( reg == SWDRegisters::SWDR_DP_RDBUFF ) )
+            {
+                // The debugger can then read the DP RDBUFF register to obtain the last AP read result.
+                swdRegCouple.reg.prev = lastRegister;
+                swdRegCouple.reg.current = reg;
+                numApReads = 0;
+                lastRegister = SWDRegisters::SWDR_UNDEFINED;
+            }
+            else
+            {
+                swdRegCouple.reg.prev = SWDRegisters::SWDR_UNDEFINED;
+                swdRegCouple.reg.current = reg;
+            }
+        }
+    }
+    else
+    {
+        swdRegCouple.reg.prev = SWDRegisters::SWDR_UNDEFINED;
+        swdRegCouple.reg.current = reg;
+        numApReads = 0;
+        lastRegister = SWDRegisters::SWDR_UNDEFINED;
+    }
+
+    f.mData1 = data;
+    f.mData2 = swdRegCouple.blob;
+    pResults->AddFrame( f );
+
+    // data parity
+    f = bi[ 32u ].MakeFrame();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DATA_PARITY );
+    f.mData1 = dataParity;
+    f.mData2 = dataParityOk ? 1 : 0;
+    pResults->AddFrame( f );
+
+    if( IsRead() )
+    {
+        // add turnaround on read operation
+        f = bi[ 33u ].MakeFrame();
+        f.mEndingSampleInclusive = bi[ 33u + GetTurnaroundNumber() - 1u ].GetEndSample();
+        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_TURNAROUND );
+        pResults->AddFrame( f );
+    }
+}
+
+void SWDOperation::AddMarkers( SWDAnalyzerResults* pResults ) const
+{
+    for( std::deque<SWDBit>::const_iterator bi( bits.begin() ); bi != bits.end(); ++bi )
+    {
+        size_t ndx = bi - bits.begin();
+
+        // turnaround
+        if( ( (ndx >= 8u) && (ndx < 8u + GetTurnaroundNumber()) ) ||
+            ( !IsRead() && ( ( ndx >= 8u + GetTurnaroundNumber() + 3u ) && ( ndx < 8u + GetTurnaroundNumber() + 3u + GetTurnaroundNumber() ) ) ) ||
+            ( IsRead() && ( ( ndx >= 8u + GetTurnaroundNumber() + 3u + 32u + 1u ) && ( ndx < 8u + GetTurnaroundNumber() + 3u + 32u + 1u + GetTurnaroundNumber() ) ) )
+        )
+        {
+            pResults->AddMarker( ( bi->falling + bi->rising ) / 2, AnalyzerResults::X, pResults->GetSettings()->mSWCLK );
+        }
+        else
+        {
+            // Data is always sampled by both ends on the rising edge.
+            pResults->AddMarker( bi->rising, bi->stateRising == BIT_HIGH ? AnalyzerResults::One : AnalyzerResults::Zero,
+                             pResults->GetSettings()->mSWCLK );
+        }
+    }
+}
+
+void SWDOperation::SetDPVer( DPVersion version )
+{
+    dpVer = version;
+}
+
+void SWDOperation::SetRegister( U32 selectReg )
+{
+
+    if( reqAPnDP ) // AccessPort or DebugPort?
+    {
+        reg = SWDRegisters::SWDR_AP_RAZ_WI;
+        if( dpVer < DPVersion::DP_V3 )
+        {
+            // MEM-AP ADIv5
+            U8 apBankSel = U8( selectReg & 0xF0u );
+            U8 apRegOffset = apBankSel | addr;
+            const auto apReg = MEM_AP_ADI_V5.find( apRegOffset );
+            if( apReg != MEM_AP_ADI_V5.end() )
+            {
+                reg = apReg->second;
+            }
+        }
+        else
+        {
+            // MEM-AP ADIv6
+            U16 apRegOffset = U16( selectReg & 0xFF0u );
+            apRegOffset |= addr;
+            const auto apReg = MEM_AP_ADI_V6.find( apRegOffset );
+            if( apReg != MEM_AP_ADI_V6.end() )
+            {
+                reg = apReg->second;
+            }
+        }
+    }
+    else
+    {
+        reg = SWDRegisters::SWDR_UNDEFINED;
+        U8 dpBankSel = selectReg & 0x0Fu;
+
+        const auto dpReg = DP_REGISTERS.find( addr );
+        if( dpReg != DP_REGISTERS.end() )
+        {
+            for( const auto& dpRegRecord : dpReg->second )
+            {
+                if( dpRegRecord.Bank.empty() || ( dpRegRecord.Bank.find( dpBankSel ) != dpRegRecord.Bank.end() ) )
+                {
+                    if( ( reqRnW && ( ( dpRegRecord.Access & static_cast<U8>( DPMask::DP_REG_READ ) ) != 0u ) ) ||
+                        ( !reqRnW && ( ( dpRegRecord.Access & static_cast<U8>( DPMask::DP_REG_WRITE ) ) != 0u ) ) )
+                    {
+                        if( ( dpVer == DPVersion::DP_V0 ) ||
+                            ( ( dpVer == DPVersion::DP_V1 ) && ( ( dpRegRecord.Access & static_cast<U8>( DPMask::DP_REG_V1 ) ) != 0u ) ) ||
+                            ( ( dpVer == DPVersion::DP_V2 ) && ( ( dpRegRecord.Access & static_cast<U8>( DPMask::DP_REG_V2 ) ) != 0u ) ) ||
+                            ( ( dpVer == DPVersion::DP_V3 ) && ( ( dpRegRecord.Access & static_cast<U8>( DPMask::DP_REG_V3 ) ) != 0u ) ) )
+                        {
+                            reg = dpRegRecord.Register;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+bool SWDOperation::IsRead() const
+{
+    return reqRnW;
+}
+
+void SWDOperation::SetTurnaroundNumber( U8 num )
+{
+    turnaround = num;
+}
+
+size_t SWDOperation::GetTurnaroundNumber() const
+{
+    return turnaround;
+}
+
+void SWDOperation::SetOrunDetect( bool enable )
+{
+    orundetect = enable;
+}
+
+bool SWDOperation::GetOrunDetect() const
+{
+    return orundetect;
+}
+
+
+// ********************************************************************************
+
+void SWDLineReset::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+
+    // line reset
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_LINE_RESET );
+    f.mData1 = bits.size();
+    pResults->AddFrame( f );
+}
+
+// ********************************************************************************
+
+void JTAGToSWD::Clear()
+{
+    deprecated = false;
+    data = 0;
+    bits.clear();
+}
+
+void JTAGToSWD::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TO_SWD );
+    f.mData1 = data;
+    f.mFlags = deprecated ? 1 : 0;
+    pResults->AddFrame( f );
+}
+
+// ********************************************************************************
+
+void SWDToJTAG::Clear()
+{
+    deprecated = false;
+    data = 0;
+    bits.clear();
+}
+
+void SWDToJTAG::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_SWD_TO_JTAG );
+    f.mData1 = data;
+    f.mFlags = deprecated ? 1 : 0;
+    pResults->AddFrame( f );
+}
+
+// ********************************************************************************
+
+void SWDErrorBits::Clear()
+{
+    protocol = DebugProtocol::DPROTOCOL_UNKNOWN;
+    bits.clear();
+}
+
+void SWDErrorBits::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+
+    // Erroneus bits
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    if( ( protocol == DebugProtocol::DPROTOCOL_UNKNOWN ) || ( protocol == DebugProtocol::DPROTOCOL_SWD ) )
+    {
+        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_ERROR );
+    }
+    else
+    {
+        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_IGNORED );
+    }
+    f.mData1 = bits.size();
+    f.mData2 = static_cast<U64>( protocol );
+    pResults->AddFrame( f );
+}
+
+void SWDErrorBits::SetProtocol( const DebugProtocol newProtocol )
+{
+    protocol = newProtocol;
+}
+
+// ********************************************************************************
+
+void SWDIdleCycles::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+
+    // Idle cycle bits
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_IDLE_CYCLE );
+    f.mData1 = bits.size();
+    pResults->AddFrame( f );
+}
+
+// ********************************************************************************
+
+void JTAGTlr::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+
+    // JTAG test logic reset
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TLR );
+    f.mData1 = bits.size();
+    pResults->AddFrame( f );
+}
+
+// ********************************************************************************
+
+void JTAGToDS::Clear()
+{
+    data = 0;
+    bits.clear();
+}
+
+void JTAGToDS::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TO_DS );
+    f.mData1 = data;
+    pResults->AddFrame( f );
+}
+
+// ********************************************************************************
+
+void SWDToDS::Clear()
+{
+    data = 0;
+    bits.clear();
+}
+
+void SWDToDS::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_SWD_TO_DS );
+    f.mData1 = data;
+    pResults->AddFrame( f );
+}
+
+// ********************************************************************************
+
+void DSSelectionAlertPreamble::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+
+    // DS Selection Alert sequence preamble
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_SEL_ALERT_PREAMBLE );
+    f.mData1 = bits.size();
+    pResults->AddFrame( f );
+}
+
+// ********************************************************************************
+
+void DSSelectionAlert::Clear()
+{
+    hi64BitData = 0;
+    lo64BitData = 0;
+    bits.clear();
+}
+
+void DSSelectionAlert::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+
+    // DS Selection Alert sequence
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_SEL_ALERT );
+    f.mData1 = lo64BitData;
+    f.mData2 = hi64BitData;
+    pResults->AddFrame( f );
+}
+
+// ********************************************************************************
+
+void DSActivationCodePreamble::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+
+    // DS Activation Code sequence preamble
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE_PREAMBLE );
+    f.mData1 = bits.size();
+    pResults->AddFrame( f );
+}
+
+// ********************************************************************************
+
+void DSActivationCode::Clear()
+{
+    data = 0;
+    bits.clear();
+}
+
+void DSActivationCode::AddFrames( SWDAnalyzerResults* pResults ) const
+{
+    Frame f;
+
+    // DS Activation code
+    f.mStartingSampleInclusive = bits.front().GetStartSample();
+    f.mEndingSampleInclusive = bits.back().GetEndSample();
+    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE );
+    f.mData1 = data;
+    pResults->AddFrame( f );
+}
+
+// ********************************************************************************
+
+void SWDRequestFrame::SetRequestByte( U8 requestByte )
+{
+    mData1 = requestByte;
+}
+
+U8 SWDRequestFrame::GetAddr() const
+{
+    return static_cast<U8>( ( mData1 >> 1 ) & 0xc );
+}
+
+bool SWDRequestFrame::IsRead() const
+{
+    return ( mFlags & IS_READ ) != 0;
+}
+
+bool SWDRequestFrame::IsAccessPort() const
+{
+    return ( mFlags & IS_ACCESS_PORT ) != 0;
+}
+
+bool SWDRequestFrame::IsDebugPort() const
+{
+    return !IsAccessPort();
+}
+
+void SWDRequestFrame::SetRegister( SWDRegisters reg )
+{
+    mData2 = static_cast<U64>(reg);
+}
+
+SWDRegisters SWDRequestFrame::GetRegister() const
+{
+    return SWDRegisters( mData2 );
+}
 
 std::string SWDRequestFrame::GetRegisterName() const
 {
@@ -56,203 +1015,226 @@ std::string SWDRequestFrame::GetRegisterName() const
 
 // ********************************************************************************
 
-void SWDOperation::Clear()
+SWDBit SWDParser::ParseBit()
 {
-    RnW = APnDP = parity_read = data_parity_ok = false;
-    addr = parity_read = request_byte = ACK = data_parity = data = 0;
-    reg = SWDR_undefined;
+    SWDBit rbit;
 
-    bits.clear();
+    assert( mSWCLK->GetBitState() == BIT_LOW );
+
+    rbit.lowStart = mSWCLK->GetSampleNumber();
+
+    // sample the rising edge 1 sample before the the actual
+    mSWCLK->AdvanceToAbsPosition( mSWCLK->GetSampleOfNextEdge() - 1 );
+    mSWDIO->AdvanceToAbsPosition( mSWCLK->GetSampleNumber() );
+    rbit.rising = mSWCLK->GetSampleNumber();
+    rbit.stateRising = mSWDIO->GetBitState();
+    mSWCLK->AdvanceToNextEdge();
+    mSWDIO->AdvanceToAbsPosition( mSWCLK->GetSampleNumber() );
+
+    /*
+    // go to the rising eggde
+    mSWCLK->AdvanceToNextEdge();
+    mSWDIO->AdvanceToAbsPosition(mSWCLK->GetSampleNumber());
+
+    rbit.rising = mSWCLK->GetSampleNumber();
+    rbit.state_rising = mSWDIO->GetBitState();
+    */
+
+    // go to the falling edge
+    mSWCLK->AdvanceToNextEdge();
+    mSWDIO->AdvanceToAbsPosition( mSWCLK->GetSampleNumber() );
+
+    rbit.falling = mSWCLK->GetSampleNumber();
+    rbit.stateFalling = mSWDIO->GetBitState();
+
+    rbit.lowEnd = mSWCLK->GetSampleOfNextEdge();
+
+    return rbit;
 }
 
-void SWDOperation::AddFrames( SWDAnalyzerResults* pResults )
+void SWDParser::CopyBits( std::deque<SWDBit>& destination, const size_t numBits )
 {
-    Frame f;
-
-    assert( bits.size() >= TRAN_REQ_AND_ACK );
-
-    // request
-    SWDRequestFrame req;
-    req.mStartingSampleInclusive = bits[ 0 ].GetStartSample();
-    req.mEndingSampleInclusive = bits[ 7 ].GetEndSample();
-    req.mFlags = ( IsRead() ? SWDRequestFrame::IS_READ : 0 ) | ( APnDP ? SWDRequestFrame::IS_ACCESS_PORT : 0 );
-    req.SetRequestByte( request_byte );
-    req.SetRegister( reg );
-    req.mType = SWDFT_Request;
-    pResults->AddFrame( req );
-
-    // turnaround
-    f = bits[ 8 ].MakeFrame();
-    f.mType = SWDFT_Turnaround;
-    pResults->AddFrame( f );
-
-    // ack
-    f.mStartingSampleInclusive = bits[ 9 ].GetStartSample();
-    f.mEndingSampleInclusive = bits[ 11 ].GetEndSample();
-    f.mType = SWDFT_ACK;
-    f.mData1 = ACK;
-    pResults->AddFrame( f );
-
-    if( bits.size() < TRAN_READ_LENGTH )
-        return;
-
-    // turnaround
-    std::vector<SWDBit>::iterator bi( bits.begin() + 12 );
-    if( !IsRead() )
+    // clear destination before populating
+    destination.clear();
+    if( numBits > mBitsBuffer.size() / 2 )
     {
-        f = bits[ 12 ].MakeFrame();
-        f.mType = SWDFT_Turnaround;
-        pResults->AddFrame( f );
-        bi++;
-    }
-
-    // data
-    f = bi->MakeFrame();
-    f.mEndingSampleInclusive = bi[ 31 ].GetEndSample();
-    if( IsRead() )
-    {
-        f.mType = SWDFT_RData;
-    } else {
-        f.mType = SWDFT_WData;
-    }
-    f.mData1 = data;
-    f.mData2 = reg;
-    pResults->AddFrame( f );
-
-    // data parity
-    f = bi[ 32 ].MakeFrame();
-    f.mType = SWDFT_DataParity;
-    f.mData1 = data_parity;
-    f.mData2 = data_parity_ok ? 1 : 0;
-    pResults->AddFrame( f );
-
-    bi += 33;
-
-    // do we have trailing bits?
-    if( bi < bits.end() )
-    {
-        f.mStartingSampleInclusive = bi->GetStartSample();
-        f.mEndingSampleInclusive = bits.back().GetEndSample();
-        f.mType = SWDFT_TrailingBits;
-
-        f.mFlags = 0;
-        f.mData1 = 0;
-        f.mData2 = 0;
-
-        pResults->AddFrame( f );
-    }
-}
-
-void SWDOperation::AddMarkers( SWDAnalyzerResults* pResults )
-{
-    for( std::vector<SWDBit>::iterator bi( bits.begin() ); bi != bits.end(); bi++ )
-    {
-        int ndx = bi - bits.begin();
-
-        // turnaround
-        if( ndx == 8 || ndx == 12 && !IsRead() )
-            pResults->AddMarker( ( bi->falling + bi->rising ) / 2, AnalyzerResults::X, pResults->GetSettings()->mSWCLK );
-
-        // Data is always sampled by both ends on the rising edge.
-        pResults->AddMarker( bi->rising, bi->state_rising == BIT_HIGH ? AnalyzerResults::One : AnalyzerResults::Zero,
-                                pResults->GetSettings()->mSWCLK );
-    }
-}
-
-void SWDOperation::SetRegister( U32 select_reg )
-{
-    if( APnDP ) // AccessPort or DebugPort?
-    {
-        U8 apbanksel = U8( select_reg & 0xf0 );
-        U8 apreg = apbanksel | addr;
-
-        switch( apreg )
-        {
-        case 0x00:
-            reg = SWDR_AP_CSW;
-            break;
-        case 0x04:
-            reg = SWDR_AP_TAR;
-            break;
-        case 0x0C:
-            reg = SWDR_AP_DRW;
-            break;
-        case 0x10:
-            reg = SWDR_AP_BD0;
-            break;
-        case 0x14:
-            reg = SWDR_AP_BD1;
-            break;
-        case 0x18:
-            reg = SWDR_AP_BD2;
-            break;
-        case 0x1C:
-            reg = SWDR_AP_BD3;
-            break;
-        case 0xF4:
-            reg = SWDR_AP_CFG;
-            break;
-        case 0xF8:
-            reg = SWDR_AP_BASE;
-            break;
-        case 0xFC:
-            reg = SWDR_AP_IDR;
-            break;
-        default:
-            reg = SWDR_AP_RAZ_WI;
-            break;
-        }
+        // more than half of the buffer needs to be copied, so it will be faster to do the following
+        // 1) copy the tail of the buffer into a temporary object, starting from the next after the given bit number
+        std::deque<SWDBit> mBitsBufferTail( mBitsBuffer.begin() + numBits, mBitsBuffer.end() );
+        // 2) strip tail of buffer starting from the next after the given bit number
+        mBitsBuffer.erase( mBitsBuffer.begin() + numBits, mBitsBuffer.end() );
+        // 3) give the bits to the destination object by swap with mBitsBuffer
+        std::swap( destination, mBitsBuffer );
+        // 4) keep tail of buffer because that one is probably next operation's start bit
+        std::swap( mBitsBuffer, mBitsBufferTail );
     }
     else
     {
-        switch( addr )
-        {
-        case 0x0:
-            reg = RnW ? SWDR_DP_IDCODE : SWDR_DP_ABORT;
-            break;
-        case 0x4:
-            reg = ( select_reg & 1 ) != 0 ? SWDR_DP_WCR : SWDR_DP_CTRL_STAT;
-            break;
-        case 0x8:
-            reg = RnW ? SWDR_DP_RESEND : SWDR_DP_SELECT;
-            break;
-        case 0xC:
-            reg = RnW ? SWDR_DP_RDBUFF : SWDR_DP_ROUTESEL;
-            break;
-        }
+        // less than half of the buffer needs to be copied, so it will be faster to do the following
+        // 1) copy the buffer head up to the given bit into a temporary object
+        std::deque<SWDBit> mBitsBufferHead( mBitsBuffer.begin(), mBitsBuffer.begin() + numBits );
+        // 2) strip head up to the given bit
+        mBitsBuffer.erase( mBitsBuffer.begin(), mBitsBuffer.begin() + numBits );
+        // 3) give the bits to the destination object by swap with the temporary object
+        std::swap( destination, mBitsBufferHead );
     }
 }
 
-// ********************************************************************************
-
-void SWDLineReset::AddFrames( AnalyzerResults* pResults )
+bool SWDParser::IsAtLeast( const size_t numBits, const BitState bit )
 {
-    Frame f;
+    bool result = true;
+    size_t bitCnt = 0;
 
-    // line reset
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = SWDFT_LineReset;
-    f.mData1 = bits.size();
-    pResults->AddFrame( f );
+    // we need at least num_bits with a given value
+    while( bitCnt < numBits )
+    {
+        if( bitCnt >= mBitsBuffer.size() )
+        {
+            mBitsBuffer.push_back( ParseBit() );
+        }
+
+        // we can't have a bit other than given value
+        if( mBitsBuffer[ bitCnt ].IsHigh() != ( bit == BIT_HIGH ) )
+        {
+            // Not enough bits with given value
+            result = false;
+            break;
+        };
+        bitCnt++;
+    }
+
+    return result;
 }
 
-// ********************************************************************************
-
-void SWDJtagToSwd::AddFrames( AnalyzerResults* pResults )
+size_t SWDParser::BitCount( const BitState bit, const size_t startingFromBit )
 {
-    Frame f;
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = SWDFT_JtagToSwd;
-    f.mData1 = bits.size();
-    pResults->AddFrame( f );
+    size_t bitCnt = 0;
+
+    // make sure that the startinng bit is placed in buffer
+    BufferBits( startingFromBit );
+    // Process all bits with given value
+    while( true )
+    {
+        const size_t bitIndex = startingFromBit + bitCnt;
+        if( bitIndex >= mBitsBuffer.size() )
+        {
+            mBitsBuffer.push_back( ParseBit() );
+        }
+
+        if( mBitsBuffer[ bitIndex ].IsHigh() != ( bit == BIT_HIGH ) )
+        {
+            // the bit at bitIndex does not match to the given value
+            break;
+        }
+        bitCnt++;
+    }
+
+    return bitCnt;
 }
 
-// ********************************************************************************
+bool SWDParser::IsU8Sequence( const U8* sequence, const size_t bitCnt )
+{
+    bool sequenceMatched = true;
 
+    // make sure that the required bit count are placed in buffer
+    BufferBits( bitCnt );
+    // Check for the given sequence value, transmitted LSB first
+    for( size_t sequenceCnt = 0u; sequenceCnt < bitCnt; sequenceCnt++ )
+    {
+        size_t index = sequenceCnt / ( sizeof( U8 ) * 8u );
+        size_t shift = sequenceCnt % ( sizeof( U8 ) * 8u );
+        if( mBitsBuffer[ sequenceCnt ].IsHigh() != ( ( ( sequence[ index ] >> shift ) & 0b1 ) == 0b1 ) )
+        {
+            sequenceMatched = false;
+            break;
+        }
+    }
 
-SWDParser::SWDParser() : mSWDIO( 0 ), mSWCLK( 0 )
+    return sequenceMatched;
+}
+
+bool SWDParser::IsU16Sequence( const U16* sequence, const size_t bitCnt )
+{
+    bool sequenceMatched = true;
+
+    // make sure that the required bit count are placed in buffer
+    BufferBits( bitCnt );
+    // Check for the given sequence value, transmitted LSB first
+    for( size_t sequenceCnt = 0u; sequenceCnt < bitCnt; sequenceCnt++ )
+    {
+        size_t index = sequenceCnt / ( sizeof( U16 ) * 8u );
+        size_t shift = sequenceCnt % ( sizeof( U16 ) * 8u );
+        if( mBitsBuffer[ sequenceCnt ].IsHigh() != ( ( ( sequence[ index ] >> shift ) & 0b1 ) == 0b1 ) )
+        {
+            sequenceMatched = false;
+            break;
+        }
+    }
+
+    return sequenceMatched;
+}
+
+bool SWDParser::IsU32Sequence( const U32* sequence, const size_t bitCnt )
+{
+    bool sequenceMatched = true;
+
+    // make sure that the required bit count are placed in buffer
+    BufferBits( bitCnt );
+    // Check for the given sequence value, transmitted LSB first
+    for( size_t sequenceCnt = 0u; sequenceCnt < bitCnt; sequenceCnt++ )
+    {
+        size_t index = sequenceCnt / ( sizeof( U32 ) * 8u );
+        size_t shift = sequenceCnt % ( sizeof( U32 ) * 8u );
+        if( mBitsBuffer[ sequenceCnt ].IsHigh() != ( ( ( sequence[ index ] >> shift ) & 0b1 ) == 0b1 ) )
+        {
+            sequenceMatched = false;
+            break;
+        }
+    }
+
+    return sequenceMatched;
+}
+
+bool SWDParser::IsU64Sequence( const U64* sequence, const size_t bitCnt )
+{
+    bool sequenceMatched = true;
+
+    // make sure that the required bit count are placed in buffer
+    BufferBits( bitCnt );
+    // Check for the given sequence value, transmitted LSB first
+    for( size_t sequenceCnt = 0u; sequenceCnt < bitCnt; sequenceCnt++ )
+    {
+        size_t index = sequenceCnt / ( sizeof( U64 ) * 8u );
+        size_t shift = sequenceCnt % ( sizeof( U64 ) * 8u );
+        if( mBitsBuffer[ sequenceCnt ].IsHigh() != ( ( ( sequence[ index ] >> shift ) & 0b1 ) == 0b1 ) )
+        {
+            sequenceMatched = false;
+            break;
+        }
+    }
+
+    return sequenceMatched;
+}
+
+SWDParser::SWDParser()
+    : mSWDIO( 0 ),
+      mSWCLK( 0 ),
+      mAnalyzer(),
+      mLastFrameType( SwdFrameTypes::SWD_FT_LINE_RESET ),
+      mCurrentProtocol( DebugProtocol::DPROTOCOL_UNKNOWN ),
+      mDPVersion( DPVersion::DP_V0 ),
+      mTran(),
+      mReset(),
+      mJtagToSwd(),
+      mSwdToJtag(),
+      mErrorBits(),
+      mIdleCycles(),
+      mJtagToDs(),
+      mSwdToDs(),
+      mDsSelectionAlert(),
+      mDsActivationCode(),
+      mSelectRegister()
+
 {
 }
 
@@ -271,255 +1253,660 @@ void SWDParser::Setup( AnalyzerChannelData* pSWDIO, AnalyzerChannelData* pSWCLK,
     }
 }
 
-SWDBit SWDParser::ParseBit()
+void SWDParser::Clear()
 {
-    SWDBit rbit;
-
-    assert( mSWCLK->GetBitState() == BIT_LOW );
-
-    rbit.low_start = mSWCLK->GetSampleNumber();
-
-    // sample the rising edge 1 sample before the the actual
-    mSWCLK->AdvanceToAbsPosition( mSWCLK->GetSampleOfNextEdge() - 1 );
-    mSWDIO->AdvanceToAbsPosition( mSWCLK->GetSampleNumber() );
-    rbit.rising = mSWCLK->GetSampleNumber();
-    rbit.state_rising = mSWDIO->GetBitState();
-    mSWCLK->AdvanceToNextEdge();
-    mSWDIO->AdvanceToAbsPosition( mSWCLK->GetSampleNumber() );
-
-    /*
-    // go to the rising egde
-    mSWCLK->AdvanceToNextEdge();
-    mSWDIO->AdvanceToAbsPosition(mSWCLK->GetSampleNumber());
-
-    rbit.rising = mSWCLK->GetSampleNumber();
-    rbit.state_rising = mSWDIO->GetBitState();
-    */
-
-    // go to the falling edge
-    mSWCLK->AdvanceToNextEdge();
-    mSWDIO->AdvanceToAbsPosition( mSWCLK->GetSampleNumber() );
-
-    rbit.falling = mSWCLK->GetSampleNumber();
-    rbit.state_falling = mSWDIO->GetBitState();
-
-    rbit.low_end = mSWCLK->GetSampleOfNextEdge();
-
-    return rbit;
+    mBitsBuffer.clear();
+    mSelectRegister = 0;
+    mDPVersion = DPVersion::DP_V0;
+    mLastFrameType = SwdFrameTypes::SWD_FT_LINE_RESET;
+    mCurrentProtocol = DebugProtocol::DPROTOCOL_UNKNOWN;
 }
 
-void SWDParser::BufferBits( size_t num_bits )
+void SWDParser::BufferBits( const size_t numBits )
 {
-    while( mBitsBuffer.size() < num_bits )
+    while( mBitsBuffer.size() < numBits )
         mBitsBuffer.push_back( ParseBit() );
+}
+
+SwdFrameTypes SWDParser::GetLastFrameType() const
+{
+    return mLastFrameType;
+}
+
+DebugProtocol SWDParser::GetCurrentProtocol() const
+{
+    return mCurrentProtocol;
+}
+
+void SWDParser::SetCurrentProtocol( DebugProtocol protocol )
+{
+    mCurrentProtocol = protocol;
+}
+
+void SWDParser::SetLastFrameType( SwdFrameTypes frame )
+{
+    mLastFrameType = frame;
+}
+
+void SWDParser::SetDPVersion( DPVersion version )
+{
+    mDPVersion = version;
+}
+
+DPVersion SWDParser::GetDPVersion() const
+{
+    return mDPVersion;
+}
+
+void SWDParser::SetNumTurnarounds( U8 num )
+{
+    mTran.SetTurnaroundNumber( num );
+}
+
+void SWDParser::SetOverrunDetection( bool enabled )
+{
+    mTran.SetOrunDetect( enabled );
+}
+
+void SWDParser::SetSelectRegister( U32 value )
+{
+    mSelectRegister = value;
+}
+
+
+bool SWDParser::IsOperation()
+{
+    mTran.Clear();
+
+    // read enough bits so that we don't have to worry of subscripts out of range
+    // 8bit request + turnaround bit(s) + three bits ACK = 12 bits in case 1 turnaround bit
+    size_t headerLength = 8u + mTran.GetTurnaroundNumber() + 3u;
+    BufferBits( headerLength );
+
+    // turn the request bits into a byte
+    U8 reqByte = 0u;
+    for( size_t cnt = 0u; cnt < 8u; ++cnt )
+    {
+        reqByte >>= 1u;
+        reqByte |= ( mBitsBuffer[ cnt ].IsHigh() ? 0x80u : 0u );
+    }
+    mTran.requestByte = reqByte;
+
+    SWDRequestByte requestByte(reqByte);
+
+    // are the request's constant bits (start, stop, park and parity) wrong?
+    if( !requestByte.IsByteValid() )
+    {
+        return false;
+    }
+
+    // get the indivitual bits
+    mTran.reqAPnDP = requestByte.GetAPnDP();
+    mTran.reqRnW = requestByte.GetRnW();
+    mTran.addr = requestByte.GetAddr();
+
+    // Set the actual register in this operation based on the data from the request
+    // and the previous select register state.
+    mTran.SetDPVer( mDPVersion );
+    mTran.SetRegister( mSelectRegister );
+
+    // get the ACK value
+    mTran.reqAck = ( mBitsBuffer[ 8u + mTran.GetTurnaroundNumber() + 0u ].stateRising == BIT_HIGH ? ( 1u << 0u ) : 0u ) +
+                ( mBitsBuffer[ 8u + mTran.GetTurnaroundNumber() + 1u ].stateRising == BIT_HIGH ? ( 1u << 1u ) : 0u ) +
+                ( mBitsBuffer[ 8u + mTran.GetTurnaroundNumber() + 2u ].stateRising == BIT_HIGH ? ( 1u << 2u ) : 0u );
+
+    // handling non-OK response if Overrun detection is not enabled
+    if( !mTran.orundetect && ( mTran.reqAck != static_cast<U8>( SWDAcks::ACK_OK ) ) )
+    {
+        size_t badTranLength = 8u + mTran.GetTurnaroundNumber() + 3u;
+        if( ( mTran.reqAck == static_cast<U8>( SWDAcks::ACK_WAIT ) ) || ( mTran.reqAck == static_cast<U8>( SWDAcks::ACK_FAULT ) ) )
+        {
+            // 8bit request + turnaround bit(s) + three bits ACK + turnaround bit(s) = 13 bits in case 1 turnaround bit
+            // read turnaround bit(s) after ACK
+            badTranLength += mTran.GetTurnaroundNumber();
+            // read one more bit that is turnaround after ACK
+            BufferBits( badTranLength );
+        }
+        // give the bits to the tran object
+        CopyBits( mTran.bits, badTranLength );
+
+        return true;
+    }
+
+    // for read operation:  8bit request + turnaround bit(s) + three bits ACK
+    //                      + 32bit data + parity + turnaround bit(s) = 46 bits in case 1 turnaround bit
+    // for write operation: 8bit request + turnaround bit(s) + three bits ACK
+    //                      + turnaround bit(s) + 32bit data + parity = 46 bits in case 1 turnaround bit
+    size_t tranLength = 8u + mTran.GetTurnaroundNumber() + 3u + 32u + 1u + mTran.GetTurnaroundNumber();
+
+    BufferBits( tranLength );
+
+    std::deque<SWDBit>::iterator bi( mBitsBuffer.begin() + headerLength );
+    // turnaround if write operation
+    if( !mTran.IsRead() )
+    {
+        // jump over turnaround bit if it is write operation
+        bi += mTran.GetTurnaroundNumber();
+    }
+
+    // read the data
+    mTran.data = 0u;
+    U8 check = 0u;
+    size_t ndx;
+    for( ndx = 0u; ndx < 32u; ndx++ )
+    {
+        mTran.data >>= 1u;
+
+        if( bi[ ndx ].IsHigh() )
+        {
+            mTran.data |= 0x80000000u;
+            ++check;
+        }
+    }
+
+    // data parity
+    mTran.dataParity = bi[ ndx ].IsHigh() ? 1u : 0u;
+
+    mTran.dataParityOk = ( mTran.dataParity == ( check & 1u ) );
+
+    if( !mTran.orundetect && !mTran.dataParityOk )
+        return false;
+
+    // give the bits to the tran object
+    CopyBits( mTran.bits, tranLength );
+
+    return true;
+}
+
+bool SWDParser::IsLineReset()
+{
+    const size_t minimumBitCnt = 50; // Required at least 50 bits
+    mReset.Clear();                  // Clear the bits
+
+    // we need at least 50 bits with a value of 1
+    if( !IsAtLeast( minimumBitCnt, BIT_HIGH ) )
+    {
+        // Not enough bits with value 1
+        return false;
+    };
+
+    // Get number of continuous 1
+    size_t lineResetCnt = minimumBitCnt + BitCount( BIT_HIGH, minimumBitCnt );
+
+    // Buffer 7 more bits
+    BufferBits( lineResetCnt + 7u );
+
+    U16 lastBits = 0u;
+    // get bits in the offset range from -5 to +7 around lineResetCnt
+    for( size_t i = lineResetCnt - 5u; i < lineResetCnt + 7u; ++i )
+    {
+        lastBits <<= 1u;
+        if( mBitsBuffer[ i ].IsHigh() )
+        {
+            lastBits |= 1u;
+        }
+    }
+
+    // Check if the last bits "1" is not the beginning of the next swd request
+    for( size_t i = 0; i < 5u; ++i )
+    {
+        U8 reqByte = ( lastBits >> ( 4u - i ) );
+        SWDRequestByte requestByte( reqByte );
+        if( requestByte.IsByteValid() )
+        {
+            // Detected a valid SWD request butted to SWD reset sequence
+            lineResetCnt -= ( 5u - i );
+            break;
+        }
+    }
+
+    // give the bits to the reset object
+    CopyBits( mReset.bits, lineResetCnt );
+
+    return true;
+}
+
+bool SWDParser::IsJtagToSwd()
+{
+    mJtagToSwd.Clear();
+    const U16 sequence = 0xE79E;           // 0xE79E, transmitted LSB first
+    const U16 sequenceDeprecated = 0xEDB6; // 0xEDB6, transmitted LSB first
+
+    // Check for 0xE79E value, transmitted LSB first
+    bool sequenceMatched = IsU16Sequence( &sequence );
+
+    if( sequenceMatched )
+    {
+        mJtagToSwd.data = sequence;
+    }
+    else
+    {
+        // Check for deprecated 0xEDB6 value, transmitted LSB first
+        sequenceMatched = IsU16Sequence( &sequenceDeprecated );
+
+        if( sequenceMatched )
+        {
+            mJtagToSwd.deprecated = true;
+            mJtagToSwd.data = sequenceDeprecated;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    // give the bits to the reset object
+    CopyBits( mJtagToSwd.bits, 16u );
+
+    return true;
+}
+
+bool SWDParser::IsSwdToJtag()
+{
+    mSwdToJtag.Clear();
+    const U16 sequence = 0xE73C;           // 0xE73C, transmitted LSB first
+    const U16 sequenceDeprecated = 0xAEAE; // 0xAEAE, transmitted LSB first
+
+    // Check for 0xE73C value, transmitted LSB first
+    bool sequenceMatched = IsU16Sequence( &sequence );
+
+    if( sequenceMatched )
+    {
+        mSwdToJtag.data = sequence;
+    }
+    else
+    {
+        // Check for deprecated 0xAEAE value, transmitted LSB first
+        sequenceMatched = IsU16Sequence( &sequenceDeprecated );
+
+        if( sequenceMatched )
+        {
+            mSwdToJtag.deprecated = true;
+            mSwdToJtag.data = sequenceDeprecated;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    // give the bits to the reset object
+    CopyBits( mSwdToJtag.bits, 16u );
+
+    return true;
+}
+
+bool SWDParser::IsIdleCycles()
+{
+    mIdleCycles.Clear(); // Clear the bits
+
+    // Get number of continuous 0
+    size_t idleCyclesCnt = BitCount( BIT_LOW, 0 );
+    if( idleCyclesCnt == 0 )
+    {
+        // No idle cycles found
+        return false;
+    }
+    // give the bits to the idleCycles object
+    CopyBits( mIdleCycles.bits, idleCyclesCnt );
+
+    return true;
+}
+
+bool SWDParser::IsJtagTlr()
+{
+    const size_t minimumBitCnt = 5u; // Required at least 5 bits
+    mJtagTlr.Clear();                // Clear the bits
+
+    // we need at least 5 bits with a value of 1
+    if( !IsAtLeast( minimumBitCnt, BIT_HIGH ) )
+    {
+        // Not enough bits with value 1
+        return false;
+    };
+
+    // Get number of continuous 1
+    size_t highBitCnt = minimumBitCnt + BitCount( BIT_HIGH, minimumBitCnt );
+    // give the bits to the JTAG Test Logic Reset object
+    CopyBits( mJtagTlr.bits, highBitCnt );
+
+    return true;
+}
+
+bool SWDParser::IsJtagToDs()
+{
+    mJtagToDs.Clear();
+    const U32 sequence = 0x33BBBBBA; // 0x33BBBBBA, 31 bits transmitted LSB first
+
+    bool sequenceMatched = IsU32Sequence( &sequence, 31u );
+
+    if( sequenceMatched )
+    {
+        mJtagToDs.data = sequence;
+    }
+    else
+    {
+        return false;
+    }
+    // give the bits to the JTAG-to-DS object
+    CopyBits( mJtagToDs.bits, 31u );
+
+    return true;
+}
+
+bool SWDParser::IsSwdToDs()
+{
+    mSwdToDs.Clear();
+    const U16 sequence = 0xE3BC; // 0xE3BC, transmitted LSB first
+
+    // Check for 0xE73C value, transmitted LSB first
+    bool sequenceMatched = IsU16Sequence( &sequence );
+
+    if( sequenceMatched )
+    {
+        mSwdToDs.data = sequence;
+    }
+    else
+    {
+        return false;
+    }
+
+    // give the bits to the SWD-to-DS object
+    CopyBits( mSwdToDs.bits, 16u );
+
+    return true;
+}
+
+bool SWDParser::IsDsSelectionAlertPreamble()
+{
+    const size_t minimumBitCnt = 8u;   // Required at least 8 bits
+    mDsSelectionAlertPreamble.Clear(); // Clear the bits
+
+    // we need at least 8 bits with a value of 1
+    if( !IsAtLeast( minimumBitCnt, BIT_HIGH ) )
+    {
+        // Not enough bits with value 1
+        return false;
+    };
+
+    // Get number of continuous 1
+    size_t highBitCnt = minimumBitCnt + BitCount( BIT_HIGH, minimumBitCnt );
+    // give the bits to the Selection Alert sequence preamble object
+    CopyBits( mDsSelectionAlertPreamble.bits, highBitCnt );
+
+    return true;
+}
+
+bool SWDParser::IsDsSelectionAlert()
+{
+    mDsSelectionAlert.Clear();
+    const U64 sequence[ 2u ] = {
+        0x86852D956209F392u, // Low 64 bits transmitted LSB first
+        0x19BC0EA2E3DDAFE9u  // Hihg 64 bits transmitted LSB first
+    };
+
+    bool sequenceMatched = IsU64Sequence( sequence, 128u );
+
+    if( sequenceMatched )
+    {
+        mDsSelectionAlert.hi64BitData = sequence[ 1u ];
+        mDsSelectionAlert.lo64BitData = sequence[ 0u ];
+    }
+    else
+    {
+        return false;
+    }
+    // give the bits to the DS Selection Alert sequence object
+    CopyBits( mDsSelectionAlert.bits, 128u );
+
+    return true;
+}
+
+bool SWDParser::IsDsActivationCodePreamble()
+{
+    mDsActivationCodePreamble.Clear();
+    const U8 sequence = 0x00; // 0x00, 4 cycles with SWDIOTMS LOW
+
+    // Check for 0x00 value, transmitted LSB first
+    bool sequenceMatched = IsU8Sequence( &sequence, 4u );
+
+    if( !sequenceMatched )
+    {
+        return false;
+    }
+
+    // give the bits to the SWD-to-DS object
+    CopyBits( mDsActivationCodePreamble.bits, 4u );
+
+    return true;
+}
+
+bool SWDParser::IsDsActivationCode()
+{
+    mDsActivationCode.Clear();
+    size_t sequenceLength = 0;
+
+    bool sequenceMatched = IsU16Sequence( &SEQUENCE_JTAG_SERIAL, 12u );
+
+    if( sequenceMatched )
+    {
+        mDsActivationCode.data = SEQUENCE_JTAG_SERIAL;
+        sequenceLength = 12u;
+    }
+    else
+    {
+        sequenceMatched = IsU8Sequence( &SEQUENCE_SW_DP );
+        if( sequenceMatched )
+        {
+            mDsActivationCode.data = SEQUENCE_SW_DP;
+            sequenceLength = 8u;
+        }
+        else
+        {
+            sequenceMatched = IsU8Sequence( &SEQUENCE_JTAG_DP );
+            if( sequenceMatched )
+            {
+                mDsActivationCode.data = SEQUENCE_JTAG_DP;
+                sequenceLength = 8u;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+    // give the bits to the DS Activation Code sequence object
+    CopyBits( mDsActivationCode.bits, sequenceLength );
+
+    return true;
+}
+
+
+const SWDBaseSequnce& SWDParser::GetLineReset() const
+{
+    return mReset;
+}
+const SWDBaseSequnce& SWDParser::GetJtagToSwd() const
+{
+    return mJtagToSwd;
+}
+const SWDBaseSequnce& SWDParser::GetSwdToJtag() const
+{
+    return mSwdToJtag;
+}
+const SWDBaseSequnce& SWDParser::GetOperation() const
+{
+    return mTran;
+}
+const SWDBaseSequnce& SWDParser::GetIdleCycles() const
+{
+    return mIdleCycles;
+}
+const SWDBaseSequnce& SWDParser::GetJtagTlr() const
+{
+    return mJtagTlr;
+}
+const SWDBaseSequnce& SWDParser::GetJtagToDs() const
+{
+    return mJtagToDs;
+}
+const SWDBaseSequnce& SWDParser::GetSwdToDs() const
+{
+    return mSwdToDs;
+}
+const SWDBaseSequnce& SWDParser::GetDsSelectionAlertPreamble() const
+{
+    return mDsSelectionAlertPreamble;
+}
+const SWDBaseSequnce& SWDParser::GetDsSelectionAlert() const
+{
+    return mDsSelectionAlert;
+}
+const SWDBaseSequnce& SWDParser::GetDsActivationCodePreamble() const
+{
+    return mDsActivationCodePreamble;
+}
+const SWDBaseSequnce& SWDParser::GetDsActivationCode() const
+{
+    return mDsActivationCode;
+}
+SWDErrorBits& SWDParser::GetErrorBits()
+{
+    return mErrorBits;
+}
+
+void SWDParser::SetLineReset()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_LINE_RESET;
+
+    // Forcing DP registers that are dependent on the SWD line reset.
+    // DLCR.TURNROUND <- 0; Set number of turnaround cycles to 1
+    mTran.SetTurnaroundNumber( 1u );
+    // SELECT.DPBANKSEL <- 0;
+    mSelectRegister &= 0xFFFFFFF0u;
+}
+void SWDParser::SetJtagToSwd()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_JTAG_TO_SWD;
+    mCurrentProtocol = DebugProtocol::DPROTOCOL_SWD;
+}
+void SWDParser::SetSwdToJtag()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_SWD_TO_JTAG;
+    mCurrentProtocol = DebugProtocol::DPROTOCOL_JTAG;
+}
+void SWDParser::SetOperation()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_OPERATION;
+
+    // Make further decision based on ACK
+    if( mTran.reqAck == static_cast<U8>( SWDAcks::ACK_OK ) )
+    {
+        mCurrentProtocol = DebugProtocol::DPROTOCOL_SWD;
+        switch( mTran.reg )
+        {
+            case SWDRegisters::SWDR_DP_DPIDR:
+                // if this is read DPIDR, capture the Version of the DP architecture implemented
+                switch( ( mTran.data >> 12u ) & 0x0fu )
+                {
+                case 0x01u:
+                    mDPVersion = DPVersion::DP_V1;
+                    break;
+                case 0x02u:
+                    mDPVersion = DPVersion::DP_V2;
+                    break;
+                case 0x03u:
+                    mDPVersion = DPVersion::DP_V3;
+                    break;
+                default:
+                    mDPVersion = DPVersion::DP_V0;
+                    break;
+                }
+                break;
+            case SWDRegisters::SWDR_DP_CTRL_STAT:
+                // Capture ORUNDETECT bit of DP CTRL/STAT register
+                mTran.SetOrunDetect( ( mTran.data & 0x00000001u ) != 0u );
+                break;
+            case SWDRegisters::SWDR_DP_SELECT:
+                // if this is a SELECT register write, remember the value
+                mSelectRegister = mTran.data;
+                break;
+            case SWDRegisters::SWDR_DP_DLCR:
+                // if this is a DLCR register read or write, update number of turnaround cycles
+                mTran.SetTurnaroundNumber( ( ( mTran.data >> 8u ) & 0x03u ) + 1u );
+                break;
+            default:
+                break;
+        }
+    }
+    else
+    {
+        mCurrentProtocol = DebugProtocol::DPROTOCOL_UNKNOWN;
+    }
+}
+
+void SWDParser::SetIdleCycles()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_IDLE_CYCLE;
+}
+void SWDParser::SetJtagTlr()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_JTAG_TLR;
+}
+void SWDParser::SetJtagToDs()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_JTAG_TO_DS;
+    mCurrentProtocol = DebugProtocol::DPROTOCOL_DORMANT;
+}
+void SWDParser::SetSwdToDs()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_SWD_TO_DS;
+    mCurrentProtocol = DebugProtocol::DPROTOCOL_DORMANT;
+}
+void SWDParser::SetDsSelectionAlertPreamble()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_DS_SEL_ALERT_PREAMBLE;
+}
+void SWDParser::SetDsSelectionAlert()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_DS_SEL_ALERT;
+}
+void SWDParser::SetDsActivationCodePreamble()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE_PREAMBLE;
+}
+void SWDParser::SetDsActivationCode()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE;
+    switch(mDsActivationCode.data)
+    {
+        case SEQUENCE_JTAG_SERIAL:
+        case SEQUENCE_JTAG_DP:
+            mCurrentProtocol = DebugProtocol::DPROTOCOL_JTAG;
+            break;
+        case SEQUENCE_SW_DP:
+            mCurrentProtocol = DebugProtocol::DPROTOCOL_SWD;
+            break;
+        default:
+            mCurrentProtocol = DebugProtocol::DPROTOCOL_UNKNOWN;
+            break;
+    }
+}
+
+void SWDParser::SetErrorBits()
+{
+    mLastFrameType = SwdFrameTypes::SWD_FT_ERROR;
 }
 
 SWDBit SWDParser::PopFrontBit()
 {
     assert( !mBitsBuffer.empty() );
 
-    SWDBit ret_val( mBitsBuffer.front() );
+    SWDBit retVal( mBitsBuffer.front() );
 
     // shift the elements by 1
     std::copy( mBitsBuffer.begin() + 1, mBitsBuffer.end(), mBitsBuffer.begin() );
     mBitsBuffer.pop_back();
 
-    return ret_val;
-}
-
-bool SWDParser::IsOperation( SWDOperation& tran )
-{
-    tran.Clear();
-
-    // read enough bits so that we don't have to worry of subscripts out of range
-    BufferBits( TRAN_REQ_AND_ACK );
-
-    // turn the bits into a byte
-    tran.request_byte = 0;
-    for( size_t cnt = 0; cnt < 8; ++cnt )
-    {
-        tran.request_byte >>= 1;
-        tran.request_byte |= ( mBitsBuffer[ cnt ].IsHigh() ? 0x80 : 0 );
-    }
-
-    // are the request's constant bits (start, stop & park) wrong?
-    if( ( tran.request_byte & 0xC1 ) != 0x81 )
-        return false;
-
-    // get the indivitual bits
-    tran.APnDP = ( tran.request_byte & 0x02 ) != 0;                   //(mBitsBuffer[1].state_falling == BIT_HIGH);
-    tran.RnW = ( tran.request_byte & 0x04 ) != 0;                     //(mBitsBuffer[2].state_falling == BIT_HIGH);
-    tran.addr = ( tran.request_byte & 0x18 ) >> 1;                    //(mBitsBuffer[3].state_falling == BIT_HIGH ? (1<<2) : 0)
-                                                                      //| (mBitsBuffer[4].state_falling == BIT_HIGH ? (1<<3) : 0);
-    tran.parity_read = ( ( tran.request_byte & 0x20 ) != 0 ? 1 : 0 ); //(mBitsBuffer[5].state_falling == BIT_HIGH ? 1 : 0);
-
-    // check parity
-    int check = ( mBitsBuffer[ 1 ].state_rising == BIT_HIGH ? 1 : 0 ) + ( mBitsBuffer[ 2 ].state_rising == BIT_HIGH ? 1 : 0 ) +
-                ( mBitsBuffer[ 3 ].state_rising == BIT_HIGH ? 1 : 0 ) + ( mBitsBuffer[ 4 ].state_rising == BIT_HIGH ? 1 : 0 );
-
-    if( tran.parity_read != ( check & 1 ) )
-        return false;
-
-    // Set the actual register in this operation based on the data from the request
-    // and the previous select register state.
-    tran.SetRegister( mSelectRegister );
-
-    // get the ACK value
-    tran.ACK = ( mBitsBuffer[ 9 ].state_rising == BIT_HIGH ? 1 : 0 ) + ( mBitsBuffer[ 10 ].state_rising == BIT_HIGH ? 2 : 0 ) +
-               ( mBitsBuffer[ 11 ].state_rising == BIT_HIGH ? 4 : 0 );
-
-    // we're only handling OK, WAIT and FAULT responses
-    if( tran.ACK == ACK_WAIT || tran.ACK == ACK_FAULT )
-    {
-        // copy this operation's bits
-        tran.bits.clear();
-        std::copy( mBitsBuffer.begin(), mBitsBuffer.begin() + TRAN_REQ_AND_ACK, std::back_inserter( tran.bits ) );
-
-        // consume this operation's bits
-        mBitsBuffer.erase( mBitsBuffer.begin(), mBitsBuffer.begin() + TRAN_REQ_AND_ACK );
-
-        return true;
-    }
-
-    if( tran.ACK != ACK_OK )
-        return false;
-
-    BufferBits( TRAN_READ_LENGTH );
-
-    // turnaround if write operation
-    bool read_rising = true;
-    std::vector<SWDBit>::iterator bi( mBitsBuffer.begin() + 12 );
-    if( !tran.IsRead() )
-    {
-        BufferBits( TRAN_WRITE_LENGTH );
-        ++bi;
-        // !!! read_rising = false;
-    }
-
-    // read the data
-    tran.data = 0;
-    check = 0;
-    size_t ndx;
-    for( ndx = 0; ndx < 32; ndx++ )
-    {
-        tran.data >>= 1;
-
-        if( bi[ ndx ].IsHigh( read_rising ) )
-        {
-            tran.data |= 0x80000000;
-            ++check;
-        }
-    }
-
-    // data parity
-    tran.data_parity = bi[ ndx ].IsHigh( read_rising ) ? 1 : 0;
-
-    tran.data_parity_ok = ( tran.data_parity == ( check & 1 ) );
-
-    if( !tran.data_parity_ok )
-        return false;
-
-    // if this is a SELECT register write, remember the value
-    if( tran.reg == SWDR_DP_SELECT && !tran.RnW )
-        mSelectRegister = tran.data;
-
-    // buffered trailing zeros
-    ++ndx;
-    bool all_zeros = true;
-    while( bi + ndx < mBitsBuffer.end() )
-    {
-        if( bi[ ndx ].IsHigh( read_rising ) )
-        {
-            all_zeros = false;
-            break;
-        }
-
-        ++ndx;
-    }
-
-    // if we haven't seen a high bit carry on until we do
-    if( all_zeros )
-    {
-        // read the remaining zero bits
-        SWDBit bit;
-        while( 1 )
-        {
-            bit = ParseBit();
-            if( bit.IsHigh( read_rising ) )
-                break;
-
-            mBitsBuffer.push_back( bit );
-        }
-
-        // give the bits to the tran object
-        tran.bits = mBitsBuffer;
-        mBitsBuffer.clear();
-
-        // keep the high bit because that one is probably next operation's start bit
-        mBitsBuffer.push_back( bit );
-    }
-    else
-    {
-        // copy this operation's bits
-        tran.bits.clear();
-        std::copy( mBitsBuffer.begin(), mBitsBuffer.begin() + ndx, std::back_inserter( tran.bits ) );
-
-        // remove this operation's bits from the buffer
-        mBitsBuffer.erase( mBitsBuffer.begin(), mBitsBuffer.begin() + ndx );
-    }
-
-    return true;
-}
-
-bool SWDParser::IsLineReset( SWDLineReset& reset )
-{
-    reset.Clear();
-
-    // we need at least 50 bits with a value of 1
-    for( size_t cnt = 0; cnt < 50; cnt++ )
-    {
-        if( cnt >= mBitsBuffer.size() )
-            mBitsBuffer.push_back( ParseBit() );
-
-        // we can't have a low bit
-        if( !mBitsBuffer[ cnt ].IsHigh() )
-            return false;
-    }
-
-    SWDBit bit;
-    while( true )
-    {
-        bit = ParseBit();
-        if( !bit.IsHigh() )
-            break;
-
-        mBitsBuffer.push_back( bit );
-    }
-
-    // give the bits to the reset object
-    reset.bits = mBitsBuffer;
-    mBitsBuffer.clear();
-
-    // keep the high bit because that one is probably next operation's start bit
-    mBitsBuffer.push_back( bit );
-
-    return true;
-}
-
-bool SWDParser::IsJtagToSwd( SWDJtagToSwd& jtagToSwd ) {
-    jtagToSwd.Clear();
-    uint16_t sequence = 0b0111100111100111;
-    for( size_t cnt = 0; cnt < 16; cnt++ )
-    {
-        if( cnt >= mBitsBuffer.size() )
-            mBitsBuffer.push_back( ParseBit() );
-
-        if( mBitsBuffer[ cnt ].IsHigh() != ( ( sequence >> ( 15 - cnt ) ) & 0b1 ) )
-            return false;
-    }
-
-    jtagToSwd.bits = mBitsBuffer;
-    mBitsBuffer.clear();
-
-    return true;
+    return retVal;
 }

--- a/src/SWDTypes.cpp
+++ b/src/SWDTypes.cpp
@@ -12,57 +12,49 @@
 
 // DP registers
 
-enum class DPMask : U8      // Access and version bit field
-{
-    DP_REG_READ  = 0b00001u,
-    DP_REG_WRITE = 0b00010u,
-    DP_REG_V1    = 0b00100u,
-    DP_REG_V2    = 0b01000u,
-    DP_REG_V3    = 0b10000u
-};
-U8 operator|( const DPMask a, const DPMask b )
-{
-    return ( static_cast<U8>( a ) | static_cast<U8>( b ) );
-}
-U8 operator|( const U8 a, const DPMask b )
-{
-    return ( a | static_cast<U8>( b ) );
-}
-
 const std::map<U8, std::vector<SWDOperation::DPRegister>> SWDOperation::DP_REGISTERS = {
     { 0x00u,
         {
-            { {}, DPMask::DP_REG_READ | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 , SWDRegisters::SWDR_DP_DPIDR },
-            { { 0x00u }, DPMask::DP_REG_READ | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_DPIDR },
-            { { 0x01u }, DPMask::DP_REG_READ | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_DPIDR1 },
-            { { 0x02u }, DPMask::DP_REG_READ | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_BASEPTR0 },
-            { { 0x03u }, DPMask::DP_REG_READ | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_BASEPTR1 },
-            { {}, DPMask::DP_REG_WRITE | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_ABORT }
+            { {}, RegMask::REG_READ | RegMask::REG_V1 | RegMask::REG_V2 , SWDRegisters::SWDR_DP_DPIDR },
+            { { 0x00u }, RegMask::REG_READ | RegMask::REG_V3, SWDRegisters::SWDR_DP_DPIDR },
+            { { 0x01u }, RegMask::REG_READ | RegMask::REG_V3, SWDRegisters::SWDR_DP_DPIDR1 },
+            { { 0x02u }, RegMask::REG_READ | RegMask::REG_V3, SWDRegisters::SWDR_DP_BASEPTR0 },
+            { { 0x03u }, RegMask::REG_READ | RegMask::REG_V3, SWDRegisters::SWDR_DP_BASEPTR1 },
+            { {}, RegMask::REG_WRITE | RegMask::REG_V1 | RegMask::REG_V2 | RegMask::REG_V3, SWDRegisters::SWDR_DP_ABORT }
         }
     },
     { 0x04u,
         {
-            { { 0x00u }, DPMask::DP_REG_READ | DPMask::DP_REG_WRITE | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_CTRL_STAT },
-            { { 0x01u }, DPMask::DP_REG_READ | DPMask::DP_REG_WRITE | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_DLCR },
-            { { 0x02u }, DPMask::DP_REG_READ | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_TARGETID },
-            { { 0x03u }, DPMask::DP_REG_READ | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_DLPIDR },
-            { { 0x04u }, DPMask::DP_REG_READ | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_EVENTSTAT },
-            { { 0x05u }, DPMask::DP_REG_WRITE | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_SELECT1 },
+            { { 0x00u }, RegMask::REG_READ | RegMask::REG_WRITE | RegMask::REG_V1 | RegMask::REG_V2 | RegMask::REG_V3, SWDRegisters::SWDR_DP_CTRL_STAT },
+            { { 0x01u }, RegMask::REG_READ | RegMask::REG_WRITE | RegMask::REG_V1 | RegMask::REG_V2 | RegMask::REG_V3, SWDRegisters::SWDR_DP_DLCR },
+            { { 0x02u }, RegMask::REG_READ | RegMask::REG_V2 | RegMask::REG_V3, SWDRegisters::SWDR_DP_TARGETID },
+            { { 0x03u }, RegMask::REG_READ | RegMask::REG_V2 | RegMask::REG_V3, SWDRegisters::SWDR_DP_DLPIDR },
+            { { 0x04u }, RegMask::REG_READ | RegMask::REG_V2 | RegMask::REG_V3, SWDRegisters::SWDR_DP_EVENTSTAT },
+            { { 0x05u }, RegMask::REG_WRITE | RegMask::REG_V3, SWDRegisters::SWDR_DP_SELECT1 },
         }
     },
     { 0x08u,
         {
-            { {}, DPMask::DP_REG_READ | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_RESEND },
-            { {}, DPMask::DP_REG_WRITE | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_SELECT }
+            { {}, RegMask::REG_READ | RegMask::REG_V1 | RegMask::REG_V2 | RegMask::REG_V3, SWDRegisters::SWDR_DP_RESEND },
+            { {}, RegMask::REG_WRITE | RegMask::REG_V1 | RegMask::REG_V2 | RegMask::REG_V3, SWDRegisters::SWDR_DP_SELECT }
         }
     },
     { 0x0Cu,
         {
-            { {}, DPMask::DP_REG_READ | DPMask::DP_REG_V1 | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_RDBUFF },
-            { {}, DPMask::DP_REG_WRITE | DPMask::DP_REG_V2 | DPMask::DP_REG_V3, SWDRegisters::SWDR_DP_TARGETSEL }
+            { {}, RegMask::REG_READ | RegMask::REG_V1 | RegMask::REG_V2 | RegMask::REG_V3, SWDRegisters::SWDR_DP_RDBUFF },
+            { {}, RegMask::REG_WRITE | RegMask::REG_V2 | RegMask::REG_V3, SWDRegisters::SWDR_DP_TARGETSEL }
         }
     },
 };
+
+U8 operator|( const RegMask a, const RegMask b )
+{
+    return ( static_cast<U8>( a ) | static_cast<U8>( b ) );
+}
+U8 operator|( const U8 a, const RegMask b )
+{
+    return ( a | static_cast<U8>( b ) );
+}
 
 const std::map<U8, SWDRegisters> SWDOperation::MEM_AP_ADI_V5 = {
     { 0x00u, SWDRegisters::SWDR_AP_CSW },
@@ -412,6 +404,35 @@ const std::string SWDFrame::GetSwdFrameName( SwdFrameTypes frame )
     }
 }
 
+const std::map<SwdFrameTypes, std::string> SWDFrame::FRAMEV2_NAMES = {
+    { SwdFrameTypes::SWD_FT_ERROR, "ERROR" },
+    { SwdFrameTypes::SWD_FT_IGNORED, "IGNORED" },
+    { SwdFrameTypes::SWD_FT_LINE_RESET, "LINE_RESET" },
+    { SwdFrameTypes::SWD_FT_JTAG_TO_SWD, "JTAG_TO_SWD" },
+    { SwdFrameTypes::SWD_FT_SWD_TO_JTAG, "SWD_TO_JTAG" },
+    { SwdFrameTypes::SWD_FT_IDLE_CYCLE, "IDLE_CYCLE" },
+    { SwdFrameTypes::SWD_FT_JTAG_TLR, "JTAG_TLR" },
+    { SwdFrameTypes::SWD_FT_JTAG_TO_DS, "JTAG_TO_DS" },
+    { SwdFrameTypes::SWD_FT_SWD_TO_DS, "SWD_TO_DS" },
+    { SwdFrameTypes::SWD_FT_DS_SEL_ALERT_PREAMBLE, "DS_SEL_ALERT_PREAMBLE" },
+    { SwdFrameTypes::SWD_FT_DS_SEL_ALERT, "DS_SEL_ALERT" },
+    { SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE_PREAMBLE, "DS_ACTIVATION_CODE_PREAMBLE" },
+    { SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE, "DS_ACTIVATION_CODE" }
+};
+
+const std::string SWDFrame::GetSwdFrameV2Name( SwdFrameTypes frame )
+{
+    auto search = FRAMEV2_NAMES.find( frame );
+    if( search != FRAMEV2_NAMES.end() )
+    {
+        return search->second;
+    }
+    else
+    {
+        return "UNKNOWN";
+    }
+}
+
 // ********************************************************************************
 
 bool SWDBit::IsHigh( bool isRising ) const
@@ -447,6 +468,20 @@ Frame SWDBit::MakeFrame() const
 
     f.mData1 = stateRising == BIT_HIGH ? 1 : 0;
     f.mData2 = 0;
+
+    return f;
+}
+
+Frame SWDBit::MakeFrame( const S64 startingSampleInclusive, const S64 endingSampleInclusive, const U64 data1, const U64 data2, const U8 type, const U8 flags ) const
+{
+    Frame f;
+
+    f.mStartingSampleInclusive = startingSampleInclusive;
+    f.mEndingSampleInclusive = endingSampleInclusive;
+    f.mData1 = data1;
+    f.mData2 = data2;
+    f.mType = type;
+    f.mFlags = flags;
 
     return f;
 }
@@ -489,7 +524,7 @@ void SWDBaseSequnce::Clear()
     bits.clear();
 }
 
-void SWDBaseSequnce::AddFrames( SWDAnalyzerResults* pResults ) const
+void SWDBaseSequnce::AddFrames( SWDAnalyzerResults* pResults )
 {
 }
 
@@ -508,39 +543,36 @@ void SWDOperation::Clear()
     bits.clear();
 }
 
-void SWDOperation::AddFrames( SWDAnalyzerResults* pResults ) const
+void SWDOperation::AddFrames( SWDAnalyzerResults* pResults )
 {
-    static size_t numApReads = 0;
-    static SWDRegisters lastRegister = SWDRegisters::SWDR_UNDEFINED;
+    Frame frame;
 
-    Frame f;
-
-    assert( bits.size() >= 8u + GetTurnaroundNumber() + 3u );
+    const size_t trnNr = GetTurnaroundNumber();
+    assert( bits.size() >= 8u + trnNr + 3u );
 
     // request
-    SWDRequestFrame req;
-    req.mStartingSampleInclusive = bits[ 0u ].GetStartSample();
-    req.mEndingSampleInclusive = bits[ 7u ].GetEndSample();
-    req.mFlags = ( IsRead() ? SWDRequestFrame::IS_READ : 0u ) | ( reqAPnDP ? SWDRequestFrame::IS_ACCESS_PORT : 0u );
-    req.SetRequestByte( requestByte );
-    req.SetRegister( reg );
-    req.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_REQUEST );
-    pResults->AddFrame( req );
+    std::deque<SWDBit>::const_iterator bi( bits.begin() );
+    const S64 opStartSample = bi[ 0u ].GetStartSample();
+    S64 endSample = bi[ 7u ].GetEndSample();
+    frame = bi->MakeFrame( opStartSample, endSample, requestByte, static_cast<U64>( reg ), static_cast<U8>( SwdFrameTypes::SWD_FT_REQUEST ),
+                           ( IsRead() ? static_cast<U8>( SWDRequestFrame::RQ_FLAG::IS_READ ) : 0u ) |
+                               ( reqAPnDP ? static_cast<U8>( SWDRequestFrame::RQ_FLAG::IS_ACCESS_PORT ) : 0u ) );
+    pResults->AddFrame( frame );
+    bi += 8u;
 
-    std::deque<SWDBit>::const_iterator bi( bits.begin() + 8u );
     // turnaround
-    f = bi->MakeFrame();
-    f.mEndingSampleInclusive = bi[ GetTurnaroundNumber() - 1u ].GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_TURNAROUND );
-    pResults->AddFrame( f );
-    bi += GetTurnaroundNumber();
+    S64 startSample = bi[ 0u ].GetStartSample();
+    endSample = bi[ trnNr - 1u ].GetEndSample();
+    frame =
+        bi->MakeFrame( startSample, endSample, bi[ 0u ].IsHigh() ? 1u : 0u, 0u, static_cast<U8>( SwdFrameTypes::SWD_FT_TURNAROUND ), 0u );
+    pResults->AddFrame( frame );
+    bi += trnNr;
 
     // ack
-    f = bi->MakeFrame();
-    f.mEndingSampleInclusive = bi[ 2u ].GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_ACK );
-    f.mData1 = reqAck;
-    pResults->AddFrame( f );
+    startSample = bi[ 0u ].GetStartSample();
+    endSample = bi[ 2u ].GetEndSample();
+    frame = bi->MakeFrame( startSample, endSample, reqAck, 0u, static_cast<U8>( SwdFrameTypes::SWD_FT_ACK ), 0u );
+    pResults->AddFrame( frame );
     bi += 3u;
 
     // turnaround if ACK is WAIT or FAULT or OK with write operation
@@ -548,47 +580,46 @@ void SWDOperation::AddFrames( SWDAnalyzerResults* pResults ) const
         ( reqAck == static_cast<U8>( SWDAcks::ACK_FAULT ) ) ||
         ( ( reqAck == static_cast<U8>( SWDAcks::ACK_OK ) ) && !IsRead() ) )
     {
-        f = bi->MakeFrame();
-        f.mEndingSampleInclusive = bi[ GetTurnaroundNumber() - 1u ].GetEndSample();
-        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_TURNAROUND );
-        pResults->AddFrame( f );
-        bi += GetTurnaroundNumber();
+        startSample = bi[ 0u ].GetStartSample();
+        endSample = bi[ trnNr - 1u ].GetEndSample();
+        frame = bi->MakeFrame( startSample, endSample, bi[ 0u ].IsHigh() ? 1u : 0u, 0u, static_cast<U8>( SwdFrameTypes::SWD_FT_TURNAROUND ), 0u );
+        pResults->AddFrame( frame );
+        bi += trnNr;
     }
-    if( bits.size() < 8u + GetTurnaroundNumber() + 3u + 32u + 1u + GetTurnaroundNumber() )
+    if( bits.size() < 8u + trnNr + 3u + 32u + 1u + trnNr )
+    {
+        FrameV2 frameV2;
+        frameV2.AddBoolean( "RnW", IsRead() );
+        frameV2.AddBoolean( "APnDP", reqAPnDP );
+        frameV2.AddString( "reg", GetRegisterName( reg ).c_str() );
+        frameV2.AddByte( "ack", reqAck );
+        pResults->AddFrameV2( frameV2, "transfer", opStartSample, endSample );
         return;
+    }
 
     // data
-    f = bi->MakeFrame();
-    f.mEndingSampleInclusive = bi[ 31u ].GetEndSample();
+    startSample = bi[ 0u ].GetStartSample();
+    endSample = bi[ 31u ].GetEndSample();
+    SWDRegistersUnion swdRegCouple{}; // Couple of previous and current SWD register
     if( IsRead() )
     {
-        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_RDATA );
-    }
-    else
-    {
-        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_WDATA );
-    }
-
-    SWDRegistersUnion swdRegCouple; // Couple of previous and current SWD register
-    if( IsRead() )
-    {
-        if( reqAPnDP )
+        if( IsAp() )
         {
             // AP read
             if( numApReads == 0 )
             {
                 // On the first AP read access, the read data that is returned is unknown. The debugger must discard this result.
-                swdRegCouple.reg.prev = reg;
-                swdRegCouple.reg.current = SWDRegisters::SWDR_UNDEFINED;
+                swdRegCouple.reg.prev = SWDRegisters::SWDR_UNDEFINED;
+                swdRegCouple.reg.current = reg; 
             }
             else
             {
                 // The next AP read access, if successful, returns the result of the previous AP read.
                 swdRegCouple.reg.prev = lastRegister;
                 swdRegCouple.reg.current = reg;
+                swdRegCouple.reg.memAddr = tar;
             }
             numApReads++;
-            lastRegister = reg;
         }
         else
         {
@@ -598,8 +629,8 @@ void SWDOperation::AddFrames( SWDAnalyzerResults* pResults ) const
                 // The debugger can then read the DP RDBUFF register to obtain the last AP read result.
                 swdRegCouple.reg.prev = lastRegister;
                 swdRegCouple.reg.current = reg;
+                swdRegCouple.reg.memAddr = tar;
                 numApReads = 0;
-                lastRegister = SWDRegisters::SWDR_UNDEFINED;
             }
             else
             {
@@ -612,41 +643,89 @@ void SWDOperation::AddFrames( SWDAnalyzerResults* pResults ) const
     {
         swdRegCouple.reg.prev = SWDRegisters::SWDR_UNDEFINED;
         swdRegCouple.reg.current = reg;
+        swdRegCouple.reg.memAddr = tar;
         numApReads = 0;
-        lastRegister = SWDRegisters::SWDR_UNDEFINED;
     }
-
-    f.mData1 = data;
-    f.mData2 = swdRegCouple.blob;
-    pResults->AddFrame( f );
+    frame = bi->MakeFrame( startSample, endSample, data, swdRegCouple.blob, IsRead() ? static_cast<U8>( SwdFrameTypes::SWD_FT_RDATA ) : static_cast<U8>( SwdFrameTypes::SWD_FT_WDATA ), 0u );
+    pResults->AddFrame( frame );
+    bi += 32u;
 
     // data parity
-    f = bi[ 32u ].MakeFrame();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DATA_PARITY );
-    f.mData1 = dataParity;
-    f.mData2 = dataParityOk ? 1 : 0;
-    pResults->AddFrame( f );
+    startSample = bi[ 0u ].GetStartSample();
+    endSample = bi[ 0u ].GetEndSample();
+    frame = bi->MakeFrame( startSample, endSample, dataParity, dataParityOk ? 1u : 0u, static_cast<U8>( SwdFrameTypes::SWD_FT_DATA_PARITY ), 0u );
+    pResults->AddFrame( frame );
+    bi += 1u;
 
     if( IsRead() )
     {
         // add turnaround on read operation
-        f = bi[ 33u ].MakeFrame();
-        f.mEndingSampleInclusive = bi[ 33u + GetTurnaroundNumber() - 1u ].GetEndSample();
-        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_TURNAROUND );
-        pResults->AddFrame( f );
+        startSample = bi[ 0u ].GetStartSample();
+        endSample = bi[ trnNr - 1u ].GetEndSample();
+        frame = bi->MakeFrame( startSample, endSample, bi[ 0u ].IsHigh() ? 1u : 0u, 0u, static_cast<U8>( SwdFrameTypes::SWD_FT_TURNAROUND ), 0u );
+        pResults->AddFrame( frame );
     }
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddBoolean( "RnW", IsRead() );
+    frameV2.AddBoolean( "APnDP", IsAp() );
+    frameV2.AddString( "reg", GetRegisterName( reg ).c_str() );
+    frameV2.AddByte( "ack", reqAck );
+    std::vector<U8> bytes = ToVectorU8( data );
+    frameV2.AddByteArray( "data", bytes.data(), bytes.size() );
+    // Add an effective AP register that refers to data
+    SWDRegisters effectiveApReg = SWDRegisters::SWDR_UNDEFINED; 
+    if( IsRead() )
+    {
+        // Read operation
+        if( IsAp() )
+        {
+            if( swdRegCouple.reg.current != SWDRegisters::SWDR_UNDEFINED )
+            {
+                effectiveApReg = swdRegCouple.reg.prev;
+            }
+        }
+        else
+        {
+            if( reg == SWDRegisters::SWDR_DP_RDBUFF )
+            {
+                effectiveApReg = swdRegCouple.reg.prev;
+            }
+        }
+    }
+    else
+    {
+        // Write operation
+        if( IsAp() )
+        {
+            effectiveApReg = swdRegCouple.reg.current;
+        }
+    }
+    if( effectiveApReg != SWDRegisters::SWDR_UNDEFINED )
+    {
+        frameV2.AddString( "apreg", ::GetRegisterName( effectiveApReg ).c_str() );
+        // Data Read/Write register
+        if( IsApDataReg( effectiveApReg ) )
+        {
+            std::vector<U8> memAddrBytes = ToVectorU8( GetMemAddr( effectiveApReg, swdRegCouple.reg.memAddr ) );
+            frameV2.AddByteArray( "memaddr", memAddrBytes.data(), memAddrBytes.size() );
+        }
+    }
+    pResults->AddFrameV2( frameV2, "transfer", opStartSample, endSample );
 }
 
 void SWDOperation::AddMarkers( SWDAnalyzerResults* pResults ) const
 {
+    const size_t trnNr = GetTurnaroundNumber();
     for( std::deque<SWDBit>::const_iterator bi( bits.begin() ); bi != bits.end(); ++bi )
     {
         size_t ndx = bi - bits.begin();
 
         // turnaround
-        if( ( (ndx >= 8u) && (ndx < 8u + GetTurnaroundNumber()) ) ||
-            ( !IsRead() && ( ( ndx >= 8u + GetTurnaroundNumber() + 3u ) && ( ndx < 8u + GetTurnaroundNumber() + 3u + GetTurnaroundNumber() ) ) ) ||
-            ( IsRead() && ( ( ndx >= 8u + GetTurnaroundNumber() + 3u + 32u + 1u ) && ( ndx < 8u + GetTurnaroundNumber() + 3u + 32u + 1u + GetTurnaroundNumber() ) ) )
+        if( ( ( ndx >= 8u ) && ( ndx < 8u + trnNr ) ) ||
+            ( !IsRead() && ( ( ndx >= 8u + trnNr + 3u ) && ( ndx < 8u + trnNr + 3u + trnNr ) ) ) ||
+            ( IsRead() && ( ( ndx >= 8u + trnNr + 3u + 32u + 1u ) && ( ndx < 8u + trnNr + 3u + 32u + 1u + trnNr ) ) )
         )
         {
             pResults->AddMarker( ( bi->falling + bi->rising ) / 2, AnalyzerResults::X, pResults->GetSettings()->mSWCLK );
@@ -674,7 +753,7 @@ void SWDOperation::SetRegister( U32 selectReg )
         if( dpVer < DPVersion::DP_V3 )
         {
             // MEM-AP ADIv5
-            U8 apBankSel = U8( selectReg & 0xF0u );
+            U8 apBankSel = static_cast<U8>( selectReg & 0xF0u );
             U8 apRegOffset = apBankSel | addr;
             const auto apReg = MEM_AP_ADI_V5.find( apRegOffset );
             if( apReg != MEM_AP_ADI_V5.end() )
@@ -685,7 +764,7 @@ void SWDOperation::SetRegister( U32 selectReg )
         else
         {
             // MEM-AP ADIv6
-            U16 apRegOffset = U16( selectReg & 0xFF0u );
+            U16 apRegOffset = static_cast<U16>( selectReg & 0xFF0u );
             apRegOffset |= addr;
             const auto apReg = MEM_AP_ADI_V6.find( apRegOffset );
             if( apReg != MEM_AP_ADI_V6.end() )
@@ -697,7 +776,7 @@ void SWDOperation::SetRegister( U32 selectReg )
     else
     {
         reg = SWDRegisters::SWDR_UNDEFINED;
-        U8 dpBankSel = selectReg & 0x0Fu;
+        U8 dpBankSel = static_cast<U8>(selectReg & 0x0Fu);
 
         const auto dpReg = DP_REGISTERS.find( addr );
         if( dpReg != DP_REGISTERS.end() )
@@ -706,13 +785,13 @@ void SWDOperation::SetRegister( U32 selectReg )
             {
                 if( dpRegRecord.Bank.empty() || ( dpRegRecord.Bank.find( dpBankSel ) != dpRegRecord.Bank.end() ) )
                 {
-                    if( ( reqRnW && ( ( dpRegRecord.Access & static_cast<U8>( DPMask::DP_REG_READ ) ) != 0u ) ) ||
-                        ( !reqRnW && ( ( dpRegRecord.Access & static_cast<U8>( DPMask::DP_REG_WRITE ) ) != 0u ) ) )
+                    if( ( reqRnW && ( ( dpRegRecord.Access & static_cast<U8>( RegMask::REG_READ ) ) != 0u ) ) ||
+                        ( !reqRnW && ( ( dpRegRecord.Access & static_cast<U8>( RegMask::REG_WRITE ) ) != 0u ) ) )
                     {
                         if( ( dpVer == DPVersion::DP_V0 ) ||
-                            ( ( dpVer == DPVersion::DP_V1 ) && ( ( dpRegRecord.Access & static_cast<U8>( DPMask::DP_REG_V1 ) ) != 0u ) ) ||
-                            ( ( dpVer == DPVersion::DP_V2 ) && ( ( dpRegRecord.Access & static_cast<U8>( DPMask::DP_REG_V2 ) ) != 0u ) ) ||
-                            ( ( dpVer == DPVersion::DP_V3 ) && ( ( dpRegRecord.Access & static_cast<U8>( DPMask::DP_REG_V3 ) ) != 0u ) ) )
+                            ( ( dpVer == DPVersion::DP_V1 ) && ( ( dpRegRecord.Access & static_cast<U8>( RegMask::REG_V1 ) ) != 0u ) ) ||
+                            ( ( dpVer == DPVersion::DP_V2 ) && ( ( dpRegRecord.Access & static_cast<U8>( RegMask::REG_V2 ) ) != 0u ) ) ||
+                            ( ( dpVer == DPVersion::DP_V3 ) && ( ( dpRegRecord.Access & static_cast<U8>( RegMask::REG_V3 ) ) != 0u ) ) )
                         {
                             reg = dpRegRecord.Register;
                             break;
@@ -727,6 +806,11 @@ void SWDOperation::SetRegister( U32 selectReg )
 bool SWDOperation::IsRead() const
 {
     return reqRnW;
+}
+
+bool SWDOperation::IsAp() const
+{
+    return reqAPnDP;
 }
 
 void SWDOperation::SetTurnaroundNumber( U8 num )
@@ -744,24 +828,92 @@ void SWDOperation::SetOrunDetect( bool enable )
     orundetect = enable;
 }
 
+void SWDOperation::SetAddrInc( U8 num )
+{
+    switch( num )
+    {
+        case static_cast<U8>(CswAddrInc::CSW_ADDRINC_DISABLED):
+            addrInc = CswAddrInc::CSW_ADDRINC_DISABLED;
+            break;
+        case static_cast<U8>( CswAddrInc::CSW_ADDRINC_SINGLE ):
+            addrInc = CswAddrInc::CSW_ADDRINC_SINGLE;
+            break;
+        case static_cast<U8>( CswAddrInc::CSW_ADDRINC_PACKED ):
+            addrInc = CswAddrInc::CSW_ADDRINC_PACKED;
+            break;
+        default:
+            addrInc = CswAddrInc::CSW_ADDRINC_RESERVED;
+            break;
+    }
+}
+
+void SWDOperation::SetDataSize( U8 num )
+{
+    switch( num )
+    {
+        case static_cast<U8>( CswSize::CSW_SIZE_8_BIT ):
+            dataSize = CswSize::CSW_SIZE_8_BIT;
+            break;
+        case static_cast<U8>( CswSize::CSW_SIZE_16_BIT ):
+            dataSize = CswSize::CSW_SIZE_16_BIT;
+            break;
+        case static_cast<U8>( CswSize::CSW_SIZE_32_BIT ):
+            dataSize = CswSize::CSW_SIZE_32_BIT;
+            break;
+        case static_cast<U8>( CswSize::CSW_SIZE_64_BIT ):
+            dataSize = CswSize::CSW_SIZE_64_BIT;
+            break;
+        case static_cast<U8>( CswSize::CSW_SIZE_128_BIT ):
+            dataSize = CswSize::CSW_SIZE_128_BIT;
+            break;
+        case static_cast<U8>( CswSize::CSW_SIZE_256_BIT ):
+            dataSize = CswSize::CSW_SIZE_256_BIT;
+            break;
+        default:
+            dataSize = CswSize::CSW_SIZE_RESERVED;
+            break;
+    }
+}
+
 bool SWDOperation::GetOrunDetect() const
 {
     return orundetect;
 }
 
+void SWDOperation::IncrementTar()
+{
+    if( addrInc == CswAddrInc::CSW_ADDRINC_SINGLE )
+    {
+        tar += ( 1u << static_cast<U8>( dataSize ));
+    }
+    else if( addrInc == CswAddrInc::CSW_ADDRINC_PACKED )
+    {
+        tar += 4u;
+    }
+}
+
 
 // ********************************************************************************
 
-void SWDLineReset::AddFrames( SWDAnalyzerResults* pResults ) const
+void SWDLineReset::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
+    size_t bitCount = bits.size();
 
-    // line reset
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_LINE_RESET );
-    f.mData1 = bits.size();
-    pResults->AddFrame( f );
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_LINE_RESET );
+    frame.mData1 = bitCount;
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( SwdFrameTypes::SWD_FT_LINE_RESET ).c_str() );
+    frameV2.AddInteger( "cycles", bitCount );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 // ********************************************************************************
@@ -773,15 +925,27 @@ void JTAGToSWD::Clear()
     bits.clear();
 }
 
-void JTAGToSWD::AddFrames( SWDAnalyzerResults* pResults ) const
+void JTAGToSWD::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TO_SWD );
-    f.mData1 = data;
-    f.mFlags = deprecated ? 1 : 0;
-    pResults->AddFrame( f );
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
+
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TO_SWD );
+    frame.mData1 = data;
+    frame.mFlags = deprecated ? 1u : 0u;
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( SwdFrameTypes::SWD_FT_JTAG_TO_SWD ).c_str() );
+    frameV2.AddInteger( "cycles", sizeof(data) * 8u );
+    std::vector<U8> bytes = ToVectorU8( data );
+    frameV2.AddByteArray( "data", bytes.data(), bytes.size() );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 // ********************************************************************************
@@ -793,15 +957,27 @@ void SWDToJTAG::Clear()
     bits.clear();
 }
 
-void SWDToJTAG::AddFrames( SWDAnalyzerResults* pResults ) const
+void SWDToJTAG::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_SWD_TO_JTAG );
-    f.mData1 = data;
-    f.mFlags = deprecated ? 1 : 0;
-    pResults->AddFrame( f );
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
+
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_SWD_TO_JTAG );
+    frame.mData1 = data;
+    frame.mFlags = deprecated ? 1 : 0;
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( SwdFrameTypes::SWD_FT_SWD_TO_JTAG ).c_str() );
+    frameV2.AddInteger( "cycles", sizeof( data ) * 8u );
+    std::vector<U8> bytes = ToVectorU8( data );
+    frameV2.AddByteArray( "data", bytes.data(), bytes.size() );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 // ********************************************************************************
@@ -812,24 +988,29 @@ void SWDErrorBits::Clear()
     bits.clear();
 }
 
-void SWDErrorBits::AddFrames( SWDAnalyzerResults* pResults ) const
+void SWDErrorBits::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
+    size_t bitCount = bits.size();
+    SwdFrameTypes frameType = ( ( protocol == DebugProtocol::DPROTOCOL_UNKNOWN ) || ( protocol == DebugProtocol::DPROTOCOL_SWD ) )
+                                  ? SwdFrameTypes::SWD_FT_ERROR
+                                  : SwdFrameTypes::SWD_FT_IGNORED;
 
-    // Erroneus bits
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    if( ( protocol == DebugProtocol::DPROTOCOL_UNKNOWN ) || ( protocol == DebugProtocol::DPROTOCOL_SWD ) )
-    {
-        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_ERROR );
-    }
-    else
-    {
-        f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_IGNORED );
-    }
-    f.mData1 = bits.size();
-    f.mData2 = static_cast<U64>( protocol );
-    pResults->AddFrame( f );
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( frameType );
+    frame.mData1 = bitCount;
+    frame.mData2 = static_cast<U64>( protocol );
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( frameType ).c_str() );
+    frameV2.AddInteger( "cycles", bitCount );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 void SWDErrorBits::SetProtocol( const DebugProtocol newProtocol )
@@ -839,30 +1020,48 @@ void SWDErrorBits::SetProtocol( const DebugProtocol newProtocol )
 
 // ********************************************************************************
 
-void SWDIdleCycles::AddFrames( SWDAnalyzerResults* pResults ) const
+void SWDIdleCycles::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
+    size_t bitCount = bits.size();
 
-    // Idle cycle bits
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_IDLE_CYCLE );
-    f.mData1 = bits.size();
-    pResults->AddFrame( f );
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_IDLE_CYCLE );
+    frame.mData1 = bitCount;
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( SwdFrameTypes::SWD_FT_IDLE_CYCLE ).c_str() );
+    frameV2.AddInteger( "cycles", bitCount );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 // ********************************************************************************
 
-void JTAGTlr::AddFrames( SWDAnalyzerResults* pResults ) const
+void JTAGTlr::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
+    size_t bitCount = bits.size();
 
-    // JTAG test logic reset
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TLR );
-    f.mData1 = bits.size();
-    pResults->AddFrame( f );
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TLR );
+    frame.mData1 = bitCount;
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( SwdFrameTypes::SWD_FT_JTAG_TLR ).c_str() );
+    frameV2.AddInteger( "cycles", bitCount );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 // ********************************************************************************
@@ -873,14 +1072,26 @@ void JTAGToDS::Clear()
     bits.clear();
 }
 
-void JTAGToDS::AddFrames( SWDAnalyzerResults* pResults ) const
+void JTAGToDS::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TO_DS );
-    f.mData1 = data;
-    pResults->AddFrame( f );
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
+
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_JTAG_TO_DS );
+    frame.mData1 = data;
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( SwdFrameTypes::SWD_FT_JTAG_TO_DS ).c_str() );
+    frameV2.AddInteger( "cycles", 31u );
+    std::vector<U8> bytes = ToVectorU8( data );
+    frameV2.AddByteArray( "data", bytes.data(), bytes.size() );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 // ********************************************************************************
@@ -891,28 +1102,49 @@ void SWDToDS::Clear()
     bits.clear();
 }
 
-void SWDToDS::AddFrames( SWDAnalyzerResults* pResults ) const
+void SWDToDS::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_SWD_TO_DS );
-    f.mData1 = data;
-    pResults->AddFrame( f );
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
+
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_SWD_TO_DS );
+    frame.mData1 = data;
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( SwdFrameTypes::SWD_FT_SWD_TO_DS ).c_str() );
+    frameV2.AddInteger( "cycles", 16u );
+    std::vector<U8> bytes = ToVectorU8( data );
+    frameV2.AddByteArray( "data", bytes.data(), bytes.size() );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 // ********************************************************************************
 
-void DSSelectionAlertPreamble::AddFrames( SWDAnalyzerResults* pResults ) const
+void DSSelectionAlertPreamble::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
+    size_t bitCount = bits.size();
 
-    // DS Selection Alert sequence preamble
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_SEL_ALERT_PREAMBLE );
-    f.mData1 = bits.size();
-    pResults->AddFrame( f );
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_SEL_ALERT_PREAMBLE );
+    frame.mData1 = bitCount;
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( SwdFrameTypes::SWD_FT_DS_SEL_ALERT_PREAMBLE ).c_str() );
+    frameV2.AddInteger( "cycles", bitCount );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 // ********************************************************************************
@@ -924,31 +1156,52 @@ void DSSelectionAlert::Clear()
     bits.clear();
 }
 
-void DSSelectionAlert::AddFrames( SWDAnalyzerResults* pResults ) const
+void DSSelectionAlert::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
 
-    // DS Selection Alert sequence
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_SEL_ALERT );
-    f.mData1 = lo64BitData;
-    f.mData2 = hi64BitData;
-    pResults->AddFrame( f );
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_SEL_ALERT );
+    frame.mData1 = hi64BitData;
+    frame.mData2 = lo64BitData;
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( SwdFrameTypes::SWD_FT_DS_SEL_ALERT ).c_str() );
+    frameV2.AddInteger( "cycles", 128u );
+    std::vector<U8> bytes = ToVectorU8( lo64BitData );
+    std::vector<U8> bytesHi = ToVectorU8( hi64BitData );
+    bytes.insert( bytes.end(), bytesHi.begin(), bytesHi.end() );
+    frameV2.AddByteArray( "data", bytes.data(), bytes.size() );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 // ********************************************************************************
 
-void DSActivationCodePreamble::AddFrames( SWDAnalyzerResults* pResults ) const
+void DSActivationCodePreamble::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
+    size_t bitCount = bits.size();
 
-    // DS Activation Code sequence preamble
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE_PREAMBLE );
-    f.mData1 = bits.size();
-    pResults->AddFrame( f );
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE_PREAMBLE );
+    frame.mData1 = bitCount;
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE_PREAMBLE ).c_str() );
+    frameV2.AddInteger( "cycles", bitCount );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 // ********************************************************************************
@@ -959,16 +1212,34 @@ void DSActivationCode::Clear()
     bits.clear();
 }
 
-void DSActivationCode::AddFrames( SWDAnalyzerResults* pResults ) const
+void DSActivationCode::AddFrames( SWDAnalyzerResults* pResults )
 {
-    Frame f;
+    S64 startSample = bits.front().GetStartSample();
+    S64 endSample = bits.back().GetEndSample();
 
-    // DS Activation code
-    f.mStartingSampleInclusive = bits.front().GetStartSample();
-    f.mEndingSampleInclusive = bits.back().GetEndSample();
-    f.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE );
-    f.mData1 = data;
-    pResults->AddFrame( f );
+    // Legacy Frame
+    Frame frame;
+    frame.mStartingSampleInclusive = startSample;
+    frame.mEndingSampleInclusive = endSample;
+    frame.mType = static_cast<U8>( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE );
+    frame.mData1 = data;
+    pResults->AddFrame( frame );
+
+    // New FrameV2 code.
+    FrameV2 frameV2;
+    frameV2.AddString( "type", SWDFrame::GetSwdFrameV2Name( SwdFrameTypes::SWD_FT_DS_ACTIVATION_CODE ).c_str() );
+    frameV2.AddInteger( "cycles", bits.size() );
+    std::vector<U8> bytes;
+    if( bits.size() == 8u )
+    {
+        bytes.push_back( static_cast<U8>( data ) );
+    }
+    else
+    {
+        bytes = ToVectorU8( data );
+    }
+    frameV2.AddByteArray( "data", bytes.data(), bytes.size() );
+    pResults->AddFrameV2( frameV2, "sequence", startSample, endSample );
 }
 
 // ********************************************************************************
@@ -985,12 +1256,12 @@ U8 SWDRequestFrame::GetAddr() const
 
 bool SWDRequestFrame::IsRead() const
 {
-    return ( mFlags & IS_READ ) != 0;
+    return ( mFlags & static_cast<U8>( RQ_FLAG::IS_READ ) ) != 0;
 }
 
 bool SWDRequestFrame::IsAccessPort() const
 {
-    return ( mFlags & IS_ACCESS_PORT ) != 0;
+    return ( mFlags & static_cast<U8>( RQ_FLAG::IS_ACCESS_PORT ) ) != 0;
 }
 
 bool SWDRequestFrame::IsDebugPort() const
@@ -1015,9 +1286,9 @@ std::string SWDRequestFrame::GetRegisterName() const
 
 // ********************************************************************************
 
-const U16 SWDParser::SEQUENCE_JTAG_SERIAL = 0x0000u;         // 0b0000_0000_0000 transmitted LSB first, JTAG-Serial
-const U8 SWDParser::SEQUENCE_SW_DP = 0x1Au;            // 0b0001_1010 transmitted LSB first, ARM CoreSight SW-DP
-const U8 SWDParser::SEQUENCE_JTAG_DP = 0x0Au;                  // 0b0000_1010 transmitted LSB first, ARM CoreSight JTAG-DP
+const U16 SWDParser::SEQUENCE_JTAG_SERIAL = 0x0000u; // 0b0000_0000_0000 transmitted LSB first, JTAG-Serial
+const U8 SWDParser::SEQUENCE_SW_DP = 0x1Au;          // 0b0001_1010 transmitted LSB first, ARM CoreSight SW-DP
+const U8 SWDParser::SEQUENCE_JTAG_DP = 0x0Au;        // 0b0000_1010 transmitted LSB first, ARM CoreSight JTAG-DP
 
 SWDBit SWDParser::ParseBit()
 {
@@ -1134,90 +1405,6 @@ size_t SWDParser::BitCount( const BitState bit, const size_t startingFromBit )
     }
 
     return bitCnt;
-}
-
-bool SWDParser::IsU8Sequence( const U8* sequence, const size_t bitCnt )
-{
-    bool sequenceMatched = true;
-
-    // make sure that the required bit count are placed in buffer
-    BufferBits( bitCnt );
-    // Check for the given sequence value, transmitted LSB first
-    for( size_t sequenceCnt = 0u; sequenceCnt < bitCnt; sequenceCnt++ )
-    {
-        size_t index = sequenceCnt / ( sizeof( U8 ) * 8u );
-        size_t shift = sequenceCnt % ( sizeof( U8 ) * 8u );
-        if( mBitsBuffer[ sequenceCnt ].IsHigh() != ( ( ( sequence[ index ] >> shift ) & 0b1 ) == 0b1 ) )
-        {
-            sequenceMatched = false;
-            break;
-        }
-    }
-
-    return sequenceMatched;
-}
-
-bool SWDParser::IsU16Sequence( const U16* sequence, const size_t bitCnt )
-{
-    bool sequenceMatched = true;
-
-    // make sure that the required bit count are placed in buffer
-    BufferBits( bitCnt );
-    // Check for the given sequence value, transmitted LSB first
-    for( size_t sequenceCnt = 0u; sequenceCnt < bitCnt; sequenceCnt++ )
-    {
-        size_t index = sequenceCnt / ( sizeof( U16 ) * 8u );
-        size_t shift = sequenceCnt % ( sizeof( U16 ) * 8u );
-        if( mBitsBuffer[ sequenceCnt ].IsHigh() != ( ( ( sequence[ index ] >> shift ) & 0b1 ) == 0b1 ) )
-        {
-            sequenceMatched = false;
-            break;
-        }
-    }
-
-    return sequenceMatched;
-}
-
-bool SWDParser::IsU32Sequence( const U32* sequence, const size_t bitCnt )
-{
-    bool sequenceMatched = true;
-
-    // make sure that the required bit count are placed in buffer
-    BufferBits( bitCnt );
-    // Check for the given sequence value, transmitted LSB first
-    for( size_t sequenceCnt = 0u; sequenceCnt < bitCnt; sequenceCnt++ )
-    {
-        size_t index = sequenceCnt / ( sizeof( U32 ) * 8u );
-        size_t shift = sequenceCnt % ( sizeof( U32 ) * 8u );
-        if( mBitsBuffer[ sequenceCnt ].IsHigh() != ( ( ( sequence[ index ] >> shift ) & 0b1 ) == 0b1 ) )
-        {
-            sequenceMatched = false;
-            break;
-        }
-    }
-
-    return sequenceMatched;
-}
-
-bool SWDParser::IsU64Sequence( const U64* sequence, const size_t bitCnt )
-{
-    bool sequenceMatched = true;
-
-    // make sure that the required bit count are placed in buffer
-    BufferBits( bitCnt );
-    // Check for the given sequence value, transmitted LSB first
-    for( size_t sequenceCnt = 0u; sequenceCnt < bitCnt; sequenceCnt++ )
-    {
-        size_t index = sequenceCnt / ( sizeof( U64 ) * 8u );
-        size_t shift = sequenceCnt % ( sizeof( U64 ) * 8u );
-        if( mBitsBuffer[ sequenceCnt ].IsHigh() != ( ( ( sequence[ index ] >> shift ) & 0b1 ) == 0b1 ) )
-        {
-            sequenceMatched = false;
-            break;
-        }
-    }
-
-    return sequenceMatched;
 }
 
 SWDParser::SWDParser()
@@ -1361,7 +1548,7 @@ bool SWDParser::IsOperation()
                 ( mBitsBuffer[ 8u + mTran.GetTurnaroundNumber() + 1u ].stateRising == BIT_HIGH ? ( 1u << 1u ) : 0u ) +
                 ( mBitsBuffer[ 8u + mTran.GetTurnaroundNumber() + 2u ].stateRising == BIT_HIGH ? ( 1u << 2u ) : 0u );
 
-    // handling non-OK response if Overrun detection is not enabled
+    // handling non-OK response if Overrun detection is not enabled or it is a write operation to the TARGETSEL register
     if( !mTran.orundetect && !isTargetSel && ( mTran.reqAck != static_cast<U8>( SWDAcks::ACK_OK ) ) )
     {
         size_t badTranLength = 8u + mTran.GetTurnaroundNumber() + 3u;
@@ -1479,7 +1666,7 @@ bool SWDParser::IsJtagToSwd()
     const U16 sequenceDeprecated = 0xEDB6; // 0xEDB6, transmitted LSB first
 
     // Check for 0xE79E value, transmitted LSB first
-    bool sequenceMatched = IsU16Sequence( &sequence );
+    bool sequenceMatched = IsUintSequence( &sequence );
 
     if( sequenceMatched )
     {
@@ -1488,7 +1675,7 @@ bool SWDParser::IsJtagToSwd()
     else
     {
         // Check for deprecated 0xEDB6 value, transmitted LSB first
-        sequenceMatched = IsU16Sequence( &sequenceDeprecated );
+        sequenceMatched = IsUintSequence( &sequenceDeprecated );
 
         if( sequenceMatched )
         {
@@ -1514,7 +1701,7 @@ bool SWDParser::IsSwdToJtag()
     const U16 sequenceDeprecated = 0xAEAE; // 0xAEAE, transmitted LSB first
 
     // Check for 0xE73C value, transmitted LSB first
-    bool sequenceMatched = IsU16Sequence( &sequence );
+    bool sequenceMatched = IsUintSequence( &sequence );
 
     if( sequenceMatched )
     {
@@ -1523,7 +1710,7 @@ bool SWDParser::IsSwdToJtag()
     else
     {
         // Check for deprecated 0xAEAE value, transmitted LSB first
-        sequenceMatched = IsU16Sequence( &sequenceDeprecated );
+        sequenceMatched = IsUintSequence( &sequenceDeprecated );
 
         if( sequenceMatched )
         {
@@ -1584,7 +1771,7 @@ bool SWDParser::IsJtagToDs()
     mJtagToDs.Clear();
     const U32 sequence = 0x33BBBBBA; // 0x33BBBBBA, 31 bits transmitted LSB first
 
-    bool sequenceMatched = IsU32Sequence( &sequence, 31u );
+    bool sequenceMatched = IsUintSequence( &sequence, 31u );
 
     if( sequenceMatched )
     {
@@ -1606,7 +1793,7 @@ bool SWDParser::IsSwdToDs()
     const U16 sequence = 0xE3BC; // 0xE3BC, transmitted LSB first
 
     // Check for 0xE73C value, transmitted LSB first
-    bool sequenceMatched = IsU16Sequence( &sequence );
+    bool sequenceMatched = IsUintSequence( &sequence );
 
     if( sequenceMatched )
     {
@@ -1651,7 +1838,7 @@ bool SWDParser::IsDsSelectionAlert()
         0x19BC0EA2E3DDAFE9u  // Hihg 64 bits transmitted LSB first
     };
 
-    bool sequenceMatched = IsU64Sequence( sequence, 128u );
+    bool sequenceMatched = IsUintSequence( sequence, 128u );
 
     if( sequenceMatched )
     {
@@ -1674,7 +1861,7 @@ bool SWDParser::IsDsActivationCodePreamble()
     const U8 sequence = 0x00; // 0x00, 4 cycles with SWDIOTMS LOW
 
     // Check for 0x00 value, transmitted LSB first
-    bool sequenceMatched = IsU8Sequence( &sequence, 4u );
+    bool sequenceMatched = IsUintSequence( &sequence, 4u );
 
     if( !sequenceMatched )
     {
@@ -1692,7 +1879,7 @@ bool SWDParser::IsDsActivationCode()
     mDsActivationCode.Clear();
     size_t sequenceLength = 0;
 
-    bool sequenceMatched = IsU16Sequence( &SEQUENCE_JTAG_SERIAL, 12u );
+    bool sequenceMatched = IsUintSequence( &SEQUENCE_JTAG_SERIAL, 12u );
 
     if( sequenceMatched )
     {
@@ -1701,7 +1888,7 @@ bool SWDParser::IsDsActivationCode()
     }
     else
     {
-        sequenceMatched = IsU8Sequence( &SEQUENCE_SW_DP );
+        sequenceMatched = IsUintSequence( &SEQUENCE_SW_DP );
         if( sequenceMatched )
         {
             mDsActivationCode.data = SEQUENCE_SW_DP;
@@ -1709,7 +1896,7 @@ bool SWDParser::IsDsActivationCode()
         }
         else
         {
-            sequenceMatched = IsU8Sequence( &SEQUENCE_JTAG_DP );
+            sequenceMatched = IsUintSequence( &SEQUENCE_JTAG_DP );
             if( sequenceMatched )
             {
                 mDsActivationCode.data = SEQUENCE_JTAG_DP;
@@ -1728,51 +1915,51 @@ bool SWDParser::IsDsActivationCode()
 }
 
 
-const SWDBaseSequnce& SWDParser::GetLineReset() const
+SWDBaseSequnce& SWDParser::GetLineReset()
 {
     return mReset;
 }
-const SWDBaseSequnce& SWDParser::GetJtagToSwd() const
+SWDBaseSequnce& SWDParser::GetJtagToSwd()
 {
     return mJtagToSwd;
 }
-const SWDBaseSequnce& SWDParser::GetSwdToJtag() const
+SWDBaseSequnce& SWDParser::GetSwdToJtag()
 {
     return mSwdToJtag;
 }
-const SWDBaseSequnce& SWDParser::GetOperation() const
+SWDBaseSequnce& SWDParser::GetOperation()
 {
     return mTran;
 }
-const SWDBaseSequnce& SWDParser::GetIdleCycles() const
+SWDBaseSequnce& SWDParser::GetIdleCycles()
 {
     return mIdleCycles;
 }
-const SWDBaseSequnce& SWDParser::GetJtagTlr() const
+SWDBaseSequnce& SWDParser::GetJtagTlr()
 {
     return mJtagTlr;
 }
-const SWDBaseSequnce& SWDParser::GetJtagToDs() const
+SWDBaseSequnce& SWDParser::GetJtagToDs()
 {
     return mJtagToDs;
 }
-const SWDBaseSequnce& SWDParser::GetSwdToDs() const
+SWDBaseSequnce& SWDParser::GetSwdToDs()
 {
     return mSwdToDs;
 }
-const SWDBaseSequnce& SWDParser::GetDsSelectionAlertPreamble() const
+SWDBaseSequnce& SWDParser::GetDsSelectionAlertPreamble()
 {
     return mDsSelectionAlertPreamble;
 }
-const SWDBaseSequnce& SWDParser::GetDsSelectionAlert() const
+SWDBaseSequnce& SWDParser::GetDsSelectionAlert()
 {
     return mDsSelectionAlert;
 }
-const SWDBaseSequnce& SWDParser::GetDsActivationCodePreamble() const
+SWDBaseSequnce& SWDParser::GetDsActivationCodePreamble()
 {
     return mDsActivationCodePreamble;
 }
-const SWDBaseSequnce& SWDParser::GetDsActivationCode() const
+SWDBaseSequnce& SWDParser::GetDsActivationCode()
 {
     return mDsActivationCode;
 }
@@ -1812,7 +1999,7 @@ void SWDParser::SetOperation()
         switch( mTran.reg )
         {
             case SWDRegisters::SWDR_DP_DPIDR:
-                // if this is read DPIDR, capture the Version of the DP architecture implemented
+                // if this is read DPIDR, capture the Version of the DP architecture implemented.
                 switch( ( mTran.data >> 12u ) & 0x0fu )
                 {
                 case 0x01u:
@@ -1830,7 +2017,7 @@ void SWDParser::SetOperation()
                 }
                 break;
             case SWDRegisters::SWDR_DP_CTRL_STAT:
-                // Capture ORUNDETECT bit of DP CTRL/STAT register
+                // Capture the ORUNDETECT bit of the DP CTRL/STAT register when reading from or writing to it.
                 mTran.SetOrunDetect( ( mTran.data & 0x00000001u ) != 0u );
                 break;
             case SWDRegisters::SWDR_DP_SELECT:
@@ -1842,12 +2029,66 @@ void SWDParser::SetOperation()
                 mTran.SetTurnaroundNumber( ( ( mTran.data >> 8u ) & 0x03u ) + 1u );
                 break;
             default:
+                if (mTran.IsRead())
+                {
+                    // Read op
+                    if( mTran.IsAp() || ( mTran.reg == SWDRegisters::SWDR_DP_RDBUFF ) )
+                    {
+                        CapureApRegData( mTran.lastRegister );
+                    }
+                }
+                else
+                {
+                    // Write op
+                    CapureApRegData( mTran.reg );
+                }
                 break;
+        }
+        // Update previous AP read operation register
+        if( mTran.IsRead() )
+        {
+            if( mTran.IsAp() )
+            {
+                mTran.lastRegister = mTran.reg;
+            }
+            else
+            {
+                if( mTran.reg == SWDRegisters::SWDR_DP_RDBUFF )
+                {
+                    mTran.lastRegister = SWDRegisters::SWDR_UNDEFINED;
+                }
+            }
+        }
+        else
+        {
+            mTran.lastRegister = SWDRegisters::SWDR_UNDEFINED;
         }
     }
     else
     {
         mCurrentProtocol = DebugProtocol::DPROTOCOL_UNKNOWN;
+    }
+}
+
+void SWDParser::CapureApRegData( SWDRegisters reg )
+{
+    switch( reg )
+    {
+    case SWDRegisters::SWDR_AP_CSW:
+        // Capture address auto-increment and packing mode, MEM-AP access size
+        mTran.SetAddrInc( ( mTran.data >> 4u ) & 0x03u );
+        mTran.SetDataSize( mTran.data & 0x07u );
+        break;
+    case SWDRegisters::SWDR_AP_TAR:
+        // Capture TAR, Transfer Address Register
+        mTran.tar = mTran.data;
+        break;
+    case SWDRegisters::SWDR_AP_DRW:
+        // Increment TAR per CSW.AddrInc
+        mTran.IncrementTar();
+        break;
+    default:
+        break;
     }
 }
 

--- a/src/SWDTypes.h
+++ b/src/SWDTypes.h
@@ -658,9 +658,9 @@ class SWDParser
     U32 mSelectRegister;
 
     // consts
-    static const U16 SEQUENCE_JTAG_SERIAL = 0x0000u; // 0b0000_0000_0000 transmitted LSB first, JTAG-Serial
-    static const U8 SEQUENCE_SW_DP = 0x1Au;          // 0b0001_1010 transmitted LSB first, ARM CoreSight SW-DP
-    static const U8 SEQUENCE_JTAG_DP = 0x0Au;        // 0b0000_1010 transmitted LSB first, ARM CoreSight JTAG-DP
+    static const U16 SEQUENCE_JTAG_SERIAL; // 0b0000_0000_0000 transmitted LSB first, JTAG-Serial
+    static const U8 SEQUENCE_SW_DP;        // 0b0001_1010 transmitted LSB first, ARM CoreSight SW-DP
+    static const U8 SEQUENCE_JTAG_DP;      // 0b0000_1010 transmitted LSB first, ARM CoreSight JTAG-DP
 
     SWDBit ParseBit();
     void CopyBits( std::deque<SWDBit>& destination, const size_t numBits );

--- a/src/SWDTypes.h
+++ b/src/SWDTypes.h
@@ -12,11 +12,13 @@ enum SWDFrameTypes
     SWDFT_Bit,
 
     SWDFT_LineReset,
+    SWDFT_JtagToSwd,
 
     SWDFT_Request,
     SWDFT_Turnaround,
     SWDFT_ACK,
     SWDFT_WData,
+    SWDFT_RData,
     SWDFT_DataParity,
     SWDFT_TrailingBits,
 };
@@ -131,6 +133,18 @@ struct SWDLineReset
     void AddFrames( AnalyzerResults* pResults );
 };
 
+struct SWDJtagToSwd
+{
+    std::vector<SWDBit> bits;
+
+    void Clear()
+    {
+        bits.clear();
+    }
+
+    void AddFrames( AnalyzerResults* pResults );
+};
+
 struct SWDRequestFrame : public Frame
 {
     // mData1 contains addr, mData2 contains the register enum
@@ -207,6 +221,7 @@ class SWDParser
 
     bool IsOperation( SWDOperation& tran );
     bool IsLineReset( SWDLineReset& reset );
+    bool IsJtagToSwd( SWDJtagToSwd& jtagToSwd );
 
     SWDBit PopFrontBit();
 };

--- a/src/SWDTypes.h
+++ b/src/SWDTypes.h
@@ -1,59 +1,400 @@
 #ifndef SWD_TYPES_H
 #define SWD_TYPES_H
 
+#include <deque>
+#include <map>
+#include <set>
+
 #include <LogicPublicTypes.h>
+#include <AnalyzerChannelData.h>
 
 #include "SWDAnalyzerResults.h"
 
-// the possible frame types
-enum SWDFrameTypes
+// Current Debug Protocol
+enum class DebugProtocol
 {
-    SWDFT_Error,
-    SWDFT_Bit,
+    DPROTOCOL_UNKNOWN,
+    DPROTOCOL_DORMANT,
+    DPROTOCOL_JTAG,
+    DPROTOCOL_SWD
+};
 
-    SWDFT_LineReset,
-    SWDFT_JtagToSwd,
+// the possible frame types
+enum class SwdFrameTypes : U8
+{
+    SWD_FT_ERROR,
+    SWD_FT_IGNORED,
+    SWD_FT_BIT,
 
-    SWDFT_Request,
-    SWDFT_Turnaround,
-    SWDFT_ACK,
-    SWDFT_WData,
-    SWDFT_RData,
-    SWDFT_DataParity,
-    SWDFT_TrailingBits,
+    SWD_FT_LINE_RESET,
+    SWD_FT_JTAG_TO_SWD,
+    SWD_FT_SWD_TO_JTAG,
+    SWD_FT_IDLE_CYCLE,
+    SWD_FT_JTAG_TLR,
+    SWD_FT_JTAG_TO_DS,
+    SWD_FT_SWD_TO_DS,
+    SWD_FT_DS_SEL_ALERT_PREAMBLE,
+    SWD_FT_DS_SEL_ALERT,
+    SWD_FT_DS_ACTIVATION_CODE_PREAMBLE,
+    SWD_FT_DS_ACTIVATION_CODE,
+
+    SWD_FT_OPERATION,
+    SWD_FT_REQUEST,
+    SWD_FT_TURNAROUND,
+    SWD_FT_ACK,
+    SWD_FT_WDATA,
+    SWD_FT_RDATA,
+    SWD_FT_DATA_PARITY
+};
+
+class SWDFrame
+{
+    static const std::map<SwdFrameTypes, std::string> FRAME_NAMES;
+
+  public:
+    static const std::string GetSwdFrameName( SwdFrameTypes frame );
+};
+
+// Version of the DP architecture implemented
+enum class DPVersion
+{
+    DP_V0 = 0, // JTAG-DP conforms ADIv5.0
+    DP_V1 = 1, // SW-DP conforms ADIv5.0
+    DP_V2 = 2, // SW-DP version 2 conforms ADIv5.2
+    DP_V3 = 3, // SW-DP version 3 conforms ADIv6
 };
 
 // the DebugPort and AccessPort registers as defined by SWD
-enum SWDRegisters
+enum class SWDRegisters
 {
-    SWDR_undefined,
+    SWDR_UNDEFINED,
 
-    // DP
-    SWDR_DP_IDCODE,
+    // DPv1
     SWDR_DP_ABORT,
+    SWDR_DP_DPIDR,
     SWDR_DP_CTRL_STAT,
-    SWDR_DP_WCR,
-    SWDR_DP_RESEND,
     SWDR_DP_SELECT,
     SWDR_DP_RDBUFF,
-    SWDR_DP_ROUTESEL,
+    SWDR_DP_DLCR,
+    SWDR_DP_RESEND,
 
-    // AP
+    // DPv2
+    SWDR_DP_TARGETID,
+    SWDR_DP_DLPIDR,
+    SWDR_DP_EVENTSTAT,
+    SWDR_DP_TARGETSEL,
+
+    // DPv3
+    SWDR_DP_DPIDR1,
+    SWDR_DP_BASEPTR0,
+    SWDR_DP_BASEPTR1,
+    SWDR_DP_SELECT1,
+
+    // MEM-AP ADIv5
     SWDR_AP_CSW,
     SWDR_AP_TAR,
+    SWDR_AP_TAR_MSW,
     SWDR_AP_DRW,
     SWDR_AP_BD0,
     SWDR_AP_BD1,
     SWDR_AP_BD2,
     SWDR_AP_BD3,
+    SWDR_AP_MBT,
+    SWDR_AP_BASE_MSW,
     SWDR_AP_CFG,
     SWDR_AP_BASE,
-    SWDR_AP_RAZ_WI,
     SWDR_AP_IDR,
+    SWDR_AP_RAZ_WI,
+
+    // MEM-APv2 ADIv6
+    SWDR_AP_DAR0,
+    SWDR_AP_DAR1,
+    SWDR_AP_DAR2,
+    SWDR_AP_DAR3,
+    SWDR_AP_DAR4,
+    SWDR_AP_DAR5,
+    SWDR_AP_DAR6,
+    SWDR_AP_DAR7,
+    SWDR_AP_DAR8,
+    SWDR_AP_DAR9,
+    SWDR_AP_DAR10,
+    SWDR_AP_DAR11,
+    SWDR_AP_DAR12,
+    SWDR_AP_DAR13,
+    SWDR_AP_DAR14,
+    SWDR_AP_DAR15,
+    SWDR_AP_DAR16,
+    SWDR_AP_DAR17,
+    SWDR_AP_DAR18,
+    SWDR_AP_DAR19,
+    SWDR_AP_DAR20,
+    SWDR_AP_DAR21,
+    SWDR_AP_DAR22,
+    SWDR_AP_DAR23,
+    SWDR_AP_DAR24,
+    SWDR_AP_DAR25,
+    SWDR_AP_DAR26,
+    SWDR_AP_DAR27,
+    SWDR_AP_DAR28,
+    SWDR_AP_DAR29,
+    SWDR_AP_DAR30,
+    SWDR_AP_DAR31,
+    SWDR_AP_DAR32,
+    SWDR_AP_DAR33,
+    SWDR_AP_DAR34,
+    SWDR_AP_DAR35,
+    SWDR_AP_DAR36,
+    SWDR_AP_DAR37,
+    SWDR_AP_DAR38,
+    SWDR_AP_DAR39,
+    SWDR_AP_DAR40,
+    SWDR_AP_DAR41,
+    SWDR_AP_DAR42,
+    SWDR_AP_DAR43,
+    SWDR_AP_DAR44,
+    SWDR_AP_DAR45,
+    SWDR_AP_DAR46,
+    SWDR_AP_DAR47,
+    SWDR_AP_DAR48,
+    SWDR_AP_DAR49,
+    SWDR_AP_DAR50,
+    SWDR_AP_DAR51,
+    SWDR_AP_DAR52,
+    SWDR_AP_DAR53,
+    SWDR_AP_DAR54,
+    SWDR_AP_DAR55,
+    SWDR_AP_DAR56,
+    SWDR_AP_DAR57,
+    SWDR_AP_DAR58,
+    SWDR_AP_DAR59,
+    SWDR_AP_DAR60,
+    SWDR_AP_DAR61,
+    SWDR_AP_DAR62,
+    SWDR_AP_DAR63,
+    SWDR_AP_DAR64,
+    SWDR_AP_DAR65,
+    SWDR_AP_DAR66,
+    SWDR_AP_DAR67,
+    SWDR_AP_DAR68,
+    SWDR_AP_DAR69,
+    SWDR_AP_DAR70,
+    SWDR_AP_DAR71,
+    SWDR_AP_DAR72,
+    SWDR_AP_DAR73,
+    SWDR_AP_DAR74,
+    SWDR_AP_DAR75,
+    SWDR_AP_DAR76,
+    SWDR_AP_DAR77,
+    SWDR_AP_DAR78,
+    SWDR_AP_DAR79,
+    SWDR_AP_DAR80,
+    SWDR_AP_DAR81,
+    SWDR_AP_DAR82,
+    SWDR_AP_DAR83,
+    SWDR_AP_DAR84,
+    SWDR_AP_DAR85,
+    SWDR_AP_DAR86,
+    SWDR_AP_DAR87,
+    SWDR_AP_DAR88,
+    SWDR_AP_DAR89,
+    SWDR_AP_DAR90,
+    SWDR_AP_DAR91,
+    SWDR_AP_DAR92,
+    SWDR_AP_DAR93,
+    SWDR_AP_DAR94,
+    SWDR_AP_DAR95,
+    SWDR_AP_DAR96,
+    SWDR_AP_DAR97,
+    SWDR_AP_DAR98,
+    SWDR_AP_DAR99,
+    SWDR_AP_DAR100,
+    SWDR_AP_DAR101,
+    SWDR_AP_DAR102,
+    SWDR_AP_DAR103,
+    SWDR_AP_DAR104,
+    SWDR_AP_DAR105,
+    SWDR_AP_DAR106,
+    SWDR_AP_DAR107,
+    SWDR_AP_DAR108,
+    SWDR_AP_DAR109,
+    SWDR_AP_DAR110,
+    SWDR_AP_DAR111,
+    SWDR_AP_DAR112,
+    SWDR_AP_DAR113,
+    SWDR_AP_DAR114,
+    SWDR_AP_DAR115,
+    SWDR_AP_DAR116,
+    SWDR_AP_DAR117,
+    SWDR_AP_DAR118,
+    SWDR_AP_DAR119,
+    SWDR_AP_DAR120,
+    SWDR_AP_DAR121,
+    SWDR_AP_DAR122,
+    SWDR_AP_DAR123,
+    SWDR_AP_DAR124,
+    SWDR_AP_DAR125,
+    SWDR_AP_DAR126,
+    SWDR_AP_DAR127,
+    SWDR_AP_DAR128,
+    SWDR_AP_DAR129,
+    SWDR_AP_DAR130,
+    SWDR_AP_DAR131,
+    SWDR_AP_DAR132,
+    SWDR_AP_DAR133,
+    SWDR_AP_DAR134,
+    SWDR_AP_DAR135,
+    SWDR_AP_DAR136,
+    SWDR_AP_DAR137,
+    SWDR_AP_DAR138,
+    SWDR_AP_DAR139,
+    SWDR_AP_DAR140,
+    SWDR_AP_DAR141,
+    SWDR_AP_DAR142,
+    SWDR_AP_DAR143,
+    SWDR_AP_DAR144,
+    SWDR_AP_DAR145,
+    SWDR_AP_DAR146,
+    SWDR_AP_DAR147,
+    SWDR_AP_DAR148,
+    SWDR_AP_DAR149,
+    SWDR_AP_DAR150,
+    SWDR_AP_DAR151,
+    SWDR_AP_DAR152,
+    SWDR_AP_DAR153,
+    SWDR_AP_DAR154,
+    SWDR_AP_DAR155,
+    SWDR_AP_DAR156,
+    SWDR_AP_DAR157,
+    SWDR_AP_DAR158,
+    SWDR_AP_DAR159,
+    SWDR_AP_DAR160,
+    SWDR_AP_DAR161,
+    SWDR_AP_DAR162,
+    SWDR_AP_DAR163,
+    SWDR_AP_DAR164,
+    SWDR_AP_DAR165,
+    SWDR_AP_DAR166,
+    SWDR_AP_DAR167,
+    SWDR_AP_DAR168,
+    SWDR_AP_DAR169,
+    SWDR_AP_DAR170,
+    SWDR_AP_DAR171,
+    SWDR_AP_DAR172,
+    SWDR_AP_DAR173,
+    SWDR_AP_DAR174,
+    SWDR_AP_DAR175,
+    SWDR_AP_DAR176,
+    SWDR_AP_DAR177,
+    SWDR_AP_DAR178,
+    SWDR_AP_DAR179,
+    SWDR_AP_DAR180,
+    SWDR_AP_DAR181,
+    SWDR_AP_DAR182,
+    SWDR_AP_DAR183,
+    SWDR_AP_DAR184,
+    SWDR_AP_DAR185,
+    SWDR_AP_DAR186,
+    SWDR_AP_DAR187,
+    SWDR_AP_DAR188,
+    SWDR_AP_DAR189,
+    SWDR_AP_DAR190,
+    SWDR_AP_DAR191,
+    SWDR_AP_DAR192,
+    SWDR_AP_DAR193,
+    SWDR_AP_DAR194,
+    SWDR_AP_DAR195,
+    SWDR_AP_DAR196,
+    SWDR_AP_DAR197,
+    SWDR_AP_DAR198,
+    SWDR_AP_DAR199,
+    SWDR_AP_DAR200,
+    SWDR_AP_DAR201,
+    SWDR_AP_DAR202,
+    SWDR_AP_DAR203,
+    SWDR_AP_DAR204,
+    SWDR_AP_DAR205,
+    SWDR_AP_DAR206,
+    SWDR_AP_DAR207,
+    SWDR_AP_DAR208,
+    SWDR_AP_DAR209,
+    SWDR_AP_DAR210,
+    SWDR_AP_DAR211,
+    SWDR_AP_DAR212,
+    SWDR_AP_DAR213,
+    SWDR_AP_DAR214,
+    SWDR_AP_DAR215,
+    SWDR_AP_DAR216,
+    SWDR_AP_DAR217,
+    SWDR_AP_DAR218,
+    SWDR_AP_DAR219,
+    SWDR_AP_DAR220,
+    SWDR_AP_DAR221,
+    SWDR_AP_DAR222,
+    SWDR_AP_DAR223,
+    SWDR_AP_DAR224,
+    SWDR_AP_DAR225,
+    SWDR_AP_DAR226,
+    SWDR_AP_DAR227,
+    SWDR_AP_DAR228,
+    SWDR_AP_DAR229,
+    SWDR_AP_DAR230,
+    SWDR_AP_DAR231,
+    SWDR_AP_DAR232,
+    SWDR_AP_DAR233,
+    SWDR_AP_DAR234,
+    SWDR_AP_DAR235,
+    SWDR_AP_DAR236,
+    SWDR_AP_DAR237,
+    SWDR_AP_DAR238,
+    SWDR_AP_DAR239,
+    SWDR_AP_DAR240,
+    SWDR_AP_DAR241,
+    SWDR_AP_DAR242,
+    SWDR_AP_DAR243,
+    SWDR_AP_DAR244,
+    SWDR_AP_DAR245,
+    SWDR_AP_DAR246,
+    SWDR_AP_DAR247,
+    SWDR_AP_DAR248,
+    SWDR_AP_DAR249,
+    SWDR_AP_DAR250,
+    SWDR_AP_DAR251,
+    SWDR_AP_DAR252,
+    SWDR_AP_DAR253,
+    SWDR_AP_DAR254,
+    SWDR_AP_DAR255,
+    SWDR_AP_TRR,
+    SWDR_AP_T0TR,
+    SWDR_AP_CFG1,
+    SWDR_AP_ITCTRL,
+    SWDR_AP_CLAIMSET,
+    SWDR_AP_CLAIMCLR,
+    SWDR_AP_DEVAFF0,
+    SWDR_AP_DEVAFF1,
+    SWDR_AP_LAR,
+    SWDR_AP_LSR,
+    SWDR_AP_AUTHSTATUS,
+    SWDR_AP_DEVARCH,
+    SWDR_AP_DEVID2,
+    SWDR_AP_DEVID1,
+    SWDR_AP_DEVID,
+    SWDR_AP_DEVTYPE,
+    SWDR_AP_PIDR4,
+    SWDR_AP_PIDR5,
+    SWDR_AP_PIDR6,
+    SWDR_AP_PIDR7,
+    SWDR_AP_PIDR0,
+    SWDR_AP_PIDR1,
+    SWDR_AP_PIDR2,
+    SWDR_AP_PIDR3,
+    SWDR_AP_CIDR0,
+    SWDR_AP_CIDR1,
+    SWDR_AP_CIDR2,
+    SWDR_AP_CIDR3
 };
 
 // some ACK values
-enum SWDACK
+enum class SWDAcks
 {
     ACK_OK = 1,
     ACK_WAIT = 2,
@@ -64,85 +405,199 @@ enum SWDACK
 // objects of this type are buffered in SWDOperation
 struct SWDBit
 {
-    BitState state_rising;
-    BitState state_falling;
+    BitState stateRising;
+    BitState stateFalling;
 
-    S64 low_start;
+    S64 lowStart;
     S64 rising;
     S64 falling;
-    S64 low_end;
+    S64 lowEnd;
 
-    bool IsHigh( bool is_rising = true ) const
-    {
-        return ( is_rising ? state_rising : state_falling ) == BIT_HIGH;
-    }
+    bool IsHigh( bool isRising = true ) const;
 
     S64 GetMinStartEnd() const;
     S64 GetStartSample() const;
     S64 GetEndSample() const;
 
-    Frame MakeFrame();
+    Frame MakeFrame() const;
+};
+
+class SWDRequestByte
+{
+    U8 byte;
+
+    public:
+    explicit SWDRequestByte( const U8 byteValue );
+    bool IsByteValid() const;
+    bool GetAPnDP() const;
+    bool GetRnW() const;
+    U8 GetAddr() const; // A[2..3]
+};
+
+union SWDRegistersUnion
+{
+    U64 blob;
+    // Encoding rules of reg
+    // prev               | current            | usecase
+    // -------------------------------------------
+    // SWDR_UNDEFINED     | not SWDR_UNDEFINED | DP Read except READBUFF, DP Write, AP Write
+    // not SWDR_UNDEFINED | SWDR_UNDEFINED     | First AP Read
+    // not SWDR_UNDEFINED | not SWDR_UNDEFINED | Next AP Reads, DP Read of READBUFF
+    struct
+    {
+        SWDRegisters prev;    // Previous SWD register
+        SWDRegisters current; // Currenr SWD register
+    } reg;
+};
+
+struct SWDBaseSequnce
+{
+    std::deque<SWDBit> bits;
+
+    virtual void Clear();
+    virtual void AddFrames( SWDAnalyzerResults* pResults ) const;
+    virtual void AddMarkers( SWDAnalyzerResults* pResults ) const;
 };
 
 // this object contains data about one SWD operation as described in section 5.3
 // of the ARM Debug Interface v5 Architecture Specification
-struct SWDOperation
+struct SWDOperation : SWDBaseSequnce
 {
     // request
-    bool APnDP;
-    bool RnW;
-    U8 addr; // A[2..3]
-
-    U8 parity_read;
-
-    U8 request_byte; // the entire request byte
-
+    bool reqAPnDP = false;
+    bool reqRnW = true;
+    U8 addr = 0u; // A[2..3]
+    U8 parityRead = 0u;
+    U8 requestByte = 0u; // the entire request byte
     // acknowledge
-    U8 ACK;
-
+    U8 reqAck = 0u;
     // data
-    U32 data;
-    U8 data_parity;
-    bool data_parity_ok;
-
-    std::vector<SWDBit> bits;
-
+    U32 data = 0u;
+    U8 dataParity = 0u;
+    bool dataParityOk = true;
     // DebugPort or AccessPort register that this operation is reading/writing
-    SWDRegisters reg;
+    DPVersion dpVer = DPVersion::DP_V0;
+    SWDRegisters reg = SWDRegisters::SWDR_UNDEFINED;
+    // Number of turnaround tristate period. Allowed range 1..4
+    U8 turnaround = 1u;
+    // Overrun detection
+    bool orundetect = false;
 
-    void Clear();
-    void AddFrames( SWDAnalyzerResults* pResults );
-    void AddMarkers( SWDAnalyzerResults* pResults );
-    void SetRegister( U32 select_reg );
-
-    bool IsRead()
+    struct DPRegister
     {
-        return RnW;
-    }
+        std::set<U8> Bank; // If empty, it covers all banks 0x0-0xF
+        U8 Access;         // Register version and access bitmask
+        SWDRegisters Register;
+    };
+
+    static const std::map<U8, std::vector<DPRegister>> DP_REGISTERS;
+    static const std::map<U8, SWDRegisters> MEM_AP_ADI_V5;
+    static const std::map<U16, SWDRegisters> MEM_AP_ADI_V6;
+
+    void Clear() override;
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
+    void AddMarkers( SWDAnalyzerResults* pResults ) const override;
+    void SetRegister( U32 selectReg );
+    void SetDPVer( DPVersion version );
+    void SetTurnaroundNumber( U8 num );
+    void SetOrunDetect( bool enable );
+
+    bool IsRead() const;
+    size_t GetTurnaroundNumber() const;
+    bool GetOrunDetect() const;
 };
 
-struct SWDLineReset
+struct SWDLineReset : SWDBaseSequnce
 {
-    std::vector<SWDBit> bits;
-
-    void Clear()
-    {
-        bits.clear();
-    }
-
-    void AddFrames( AnalyzerResults* pResults );
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
 };
 
-struct SWDJtagToSwd
+struct JTAGToSWD : SWDBaseSequnce
 {
-    std::vector<SWDBit> bits;
+    // Deprecated flag
+    bool deprecated = false;
+     // Detected sequence value
+    U16 data = 0u;
 
-    void Clear()
-    {
-        bits.clear();
-    }
+    void Clear() override;
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
+};
 
-    void AddFrames( AnalyzerResults* pResults );
+struct SWDToJTAG : SWDBaseSequnce
+{
+    // Deprecated flag
+    bool deprecated = false;
+    // Detected sequence value
+    U16 data = 0u;
+
+    void Clear() override;
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
+};
+
+struct SWDErrorBits : SWDBaseSequnce
+{
+    DebugProtocol protocol = DebugProtocol::DPROTOCOL_UNKNOWN;
+
+    void Clear() override;
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
+
+    void SetProtocol( const DebugProtocol newProtocol );
+};
+
+struct SWDIdleCycles : SWDBaseSequnce
+{
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
+};
+
+struct JTAGTlr : SWDBaseSequnce
+{
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
+};
+
+struct JTAGToDS : SWDBaseSequnce
+{
+    // Detected sequence value
+    U32 data = 0u;
+
+    void Clear() override;
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
+};
+
+struct SWDToDS : SWDBaseSequnce
+{
+    // Detected sequence value
+    U16 data = 0u;
+
+    void Clear() override;
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
+};
+
+struct DSSelectionAlertPreamble : SWDBaseSequnce
+{
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
+};
+
+struct DSSelectionAlert : SWDBaseSequnce
+{
+    U64 hi64BitData = 0u;
+    U64 lo64BitData = 0u;
+
+    void Clear() override;
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
+};
+
+struct DSActivationCodePreamble : SWDBaseSequnce
+{
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
+};
+
+struct DSActivationCode : SWDBaseSequnce
+{
+    // Detected sequence value
+    U16 data = 0u;
+
+    void Clear() override;
+    void AddFrames( SWDAnalyzerResults* pResults ) const override;
 };
 
 struct SWDRequestFrame : public Frame
@@ -156,36 +611,13 @@ struct SWDRequestFrame : public Frame
         IS_ACCESS_PORT = ( 1 << 1 ),
     };
 
-    void SetRequestByte( U8 request_byte )
-    {
-        mData1 = request_byte;
-    }
-
-    U8 GetAddr() const
-    {
-        return ( U8 )( ( mData1 >> 1 ) & 0xc );
-    }
-    bool IsRead() const
-    {
-        return ( mFlags & IS_READ ) != 0;
-    }
-    bool IsAccessPort() const
-    {
-        return ( mFlags & IS_ACCESS_PORT ) != 0;
-    }
-    bool IsDebugPort() const
-    {
-        return !IsAccessPort();
-    }
-
-    void SetRegister( SWDRegisters reg )
-    {
-        mData2 = reg;
-    }
-    SWDRegisters GetRegister() const
-    {
-        return SWDRegisters( mData2 );
-    }
+    void SetRequestByte( U8 requestByte );
+    U8 GetAddr() const;
+    bool IsRead() const;
+    bool IsAccessPort() const;
+    bool IsDebugPort() const;
+    void SetRegister( SWDRegisters reg );
+    SWDRegisters GetRegister() const;
     std::string GetRegisterName() const;
 };
 
@@ -202,26 +634,107 @@ class SWDParser
 
     SWDAnalyzer* mAnalyzer;
 
-    std::vector<SWDBit> mBitsBuffer;
+    std::deque<SWDBit> mBitsBuffer;
+
+    SwdFrameTypes mLastFrameType;
+    DebugProtocol mCurrentProtocol;
+    DPVersion mDPVersion;
+
+    // SWD sequence objects
+    SWDOperation mTran;
+    SWDLineReset mReset;
+    JTAGToSWD mJtagToSwd;
+    SWDToJTAG mSwdToJtag;
+    SWDErrorBits mErrorBits;
+    SWDIdleCycles mIdleCycles;
+    JTAGTlr mJtagTlr;
+    JTAGToDS mJtagToDs;
+    SWDToDS mSwdToDs;
+    DSSelectionAlertPreamble mDsSelectionAlertPreamble;
+    DSSelectionAlert mDsSelectionAlert;
+    DSActivationCodePreamble mDsActivationCodePreamble;
+    DSActivationCode mDsActivationCode;
+
     U32 mSelectRegister;
 
+    // consts
+    static const U16 SEQUENCE_JTAG_SERIAL = 0x0000u; // 0b0000_0000_0000 transmitted LSB first, JTAG-Serial
+    static const U8 SEQUENCE_SW_DP = 0x1Au;          // 0b0001_1010 transmitted LSB first, ARM CoreSight SW-DP
+    static const U8 SEQUENCE_JTAG_DP = 0x0Au;        // 0b0000_1010 transmitted LSB first, ARM CoreSight JTAG-DP
+
     SWDBit ParseBit();
-    void BufferBits( size_t num_bits );
+    void CopyBits( std::deque<SWDBit>& destination, const size_t numBits );
+
+    // Comparison pattern primitives
+    bool IsAtLeast( const size_t numBits, const BitState bit );
+    size_t BitCount( const BitState bit, const size_t startingFromBit = 0 );
+    bool IsU8Sequence( const U8 *sequence, const size_t bitCnt = sizeof( U8 ) * 8u );
+    bool IsU16Sequence( const U16 *sequence, const size_t bitCnt = sizeof( U16 ) * 8u );
+    bool IsU32Sequence( const U32 *sequence, const size_t bitCnt = sizeof( U32 ) * 8u );
+    bool IsU64Sequence( const U64 *sequence, const size_t bitCnt = sizeof( U64 ) * 8u );
 
   public:
     SWDParser();
 
     void Setup( AnalyzerChannelData* pSWDIO, AnalyzerChannelData* pSWCLK, SWDAnalyzer* pAnalyzer );
+    void Clear();
+    void BufferBits( const size_t numBits );
 
-    void Clear()
-    {
-        mBitsBuffer.clear();
-        mSelectRegister = 0;
-    }
+    SwdFrameTypes GetLastFrameType() const;
+    DebugProtocol GetCurrentProtocol() const;
+    DPVersion GetDPVersion() const;
 
-    bool IsOperation( SWDOperation& tran );
-    bool IsLineReset( SWDLineReset& reset );
-    bool IsJtagToSwd( SWDJtagToSwd& jtagToSwd );
+    void SetCurrentProtocol( DebugProtocol protocol );
+    void SetLastFrameType( SwdFrameTypes frame );
+    void SetDPVersion( DPVersion version );
+    void SetNumTurnarounds( U8 num );
+    void SetOverrunDetection( bool enabled );
+    void SetSelectRegister( U32 value );
+
+    // Compare methods
+    bool IsOperation();
+    bool IsLineReset();  // At least 50 SWCLKTCK cycles with SWDIOTMS HIGH.
+    bool IsJtagToSwd();
+    bool IsSwdToJtag();
+    bool IsIdleCycles(); // SWCLKTCK cycles with SWDIOTMS LOW.
+    bool IsJtagTlr();    // At least five SWCLKTCK cycles with SWDIOTMS HIGH.
+    bool IsJtagToDs();
+    bool IsSwdToDs();
+    bool IsDsSelectionAlertPreamble(); // At least eight SWCLKTCK cycles with SWDIOTMS HIGH.
+    bool IsDsSelectionAlert();         // Selection Alert sequence ( 128 cycles )
+    bool IsDsActivationCodePreamble(); // 4 cycles with SWDIOTMS LOW
+    bool IsDsActivationCode();
+
+    // Sequence getter
+    const SWDBaseSequnce& GetLineReset() const;
+    const SWDBaseSequnce& GetJtagToSwd() const;
+    const SWDBaseSequnce& GetSwdToJtag() const;
+    const SWDBaseSequnce& GetOperation() const;
+    const SWDBaseSequnce& GetIdleCycles() const;
+    const SWDBaseSequnce& GetJtagTlr() const;
+    const SWDBaseSequnce& GetJtagToDs() const;
+    const SWDBaseSequnce& GetSwdToDs() const;
+    const SWDBaseSequnce& GetDsSelectionAlertPreamble() const;
+    const SWDBaseSequnce& GetDsSelectionAlert() const;
+    const SWDBaseSequnce& GetDsActivationCodePreamble() const;
+    const SWDBaseSequnce& GetDsActivationCode() const;
+    SWDErrorBits& GetErrorBits();
+
+    // Sequence status updaters
+    void SetLineReset();
+    void SetJtagToSwd();
+    void SetSwdToJtag();
+    void SetOperation();
+    void SetIdleCycles();
+    void SetJtagTlr();
+    void SetJtagToDs();
+    void SetSwdToDs();
+    void SetDsSelectionAlertPreamble();
+    void SetDsSelectionAlert();
+    void SetDsActivationCodePreamble();
+    void SetDsActivationCode();
+
+    void SetErrorBits();
 
     SWDBit PopFrontBit();
 };

--- a/src/SWDUtils.cpp
+++ b/src/SWDUtils.cpp
@@ -3,218 +3,613 @@
 #include "SWDUtils.h"
 #include "SWDTypes.h"
 
+#include <map>
+
+const std::map<SWDRegisters, std::string> REGISTER_NAMES
+{
+    { SWDRegisters::SWDR_UNDEFINED, "??" },
+    // DPv1
+    { SWDRegisters::SWDR_DP_ABORT, "ABORT" },
+    { SWDRegisters::SWDR_DP_DPIDR, "DPIDR" },
+    { SWDRegisters::SWDR_DP_CTRL_STAT, "CTRL/STAT" },
+    { SWDRegisters::SWDR_DP_SELECT, "SELECT" },
+    { SWDRegisters::SWDR_DP_RDBUFF, "RDBUFF" },
+    { SWDRegisters::SWDR_DP_DLCR, "DLCR" },
+    { SWDRegisters::SWDR_DP_RESEND, "RESEND" },
+    // DPv2
+    { SWDRegisters::SWDR_DP_TARGETID, "TARGETID" },
+    { SWDRegisters::SWDR_DP_DLPIDR, "DLPIDR" },
+    { SWDRegisters::SWDR_DP_EVENTSTAT, "EVENTSTAT" },
+    { SWDRegisters::SWDR_DP_TARGETSEL, "TARGETSEL" },
+    // DPv3
+    { SWDRegisters::SWDR_DP_DPIDR1, "DPIDR1" },
+    { SWDRegisters::SWDR_DP_BASEPTR0, "BASEPTR0" },
+    { SWDRegisters::SWDR_DP_BASEPTR1, "BASEPTR1" },
+    { SWDRegisters::SWDR_DP_SELECT1, "SELECT1" },
+    // MEM-AP ADIv5
+    { SWDRegisters::SWDR_AP_CSW, "CSW" },
+    { SWDRegisters::SWDR_AP_TAR, "TAR" },
+    { SWDRegisters::SWDR_AP_TAR_MSW, "TAR_MSW" },
+    { SWDRegisters::SWDR_AP_DRW, "DRW" },
+    { SWDRegisters::SWDR_AP_BD0, "BD0" },
+    { SWDRegisters::SWDR_AP_BD1, "BD1" },
+    { SWDRegisters::SWDR_AP_BD2, "BD2" },
+    { SWDRegisters::SWDR_AP_BD3, "BD3" },
+    { SWDRegisters::SWDR_AP_MBT, "MBT" },
+    { SWDRegisters::SWDR_AP_BASE_MSW, "BASE_MSW" },
+    { SWDRegisters::SWDR_AP_CFG, "CFG" },
+    { SWDRegisters::SWDR_AP_BASE, "BASE" },
+    { SWDRegisters::SWDR_AP_RAZ_WI, "RAZ_WI" },
+    { SWDRegisters::SWDR_AP_IDR, "IDR" },
+    // MEM-APv2 ADIv6
+    { SWDRegisters::SWDR_AP_DAR0, "DAR0" },
+    { SWDRegisters::SWDR_AP_DAR1, "DAR1" },
+    { SWDRegisters::SWDR_AP_DAR2, "DAR2" },
+    { SWDRegisters::SWDR_AP_DAR3, "DAR3" },
+    { SWDRegisters::SWDR_AP_DAR4, "DAR4" },
+    { SWDRegisters::SWDR_AP_DAR5, "DAR5" },
+    { SWDRegisters::SWDR_AP_DAR6, "DAR6" },
+    { SWDRegisters::SWDR_AP_DAR7, "DAR7" },
+    { SWDRegisters::SWDR_AP_DAR8, "DAR8" },
+    { SWDRegisters::SWDR_AP_DAR9, "DAR9" },
+    { SWDRegisters::SWDR_AP_DAR10, "DAR10" },
+    { SWDRegisters::SWDR_AP_DAR11, "DAR11" },
+    { SWDRegisters::SWDR_AP_DAR12, "DAR12" },
+    { SWDRegisters::SWDR_AP_DAR13, "DAR13" },
+    { SWDRegisters::SWDR_AP_DAR14, "DAR14" },
+    { SWDRegisters::SWDR_AP_DAR15, "DAR15" },
+    { SWDRegisters::SWDR_AP_DAR16, "DAR16" },
+    { SWDRegisters::SWDR_AP_DAR17, "DAR17" },
+    { SWDRegisters::SWDR_AP_DAR18, "DAR18" },
+    { SWDRegisters::SWDR_AP_DAR19, "DAR19" },
+    { SWDRegisters::SWDR_AP_DAR20, "DAR20" },
+    { SWDRegisters::SWDR_AP_DAR21, "DAR21" },
+    { SWDRegisters::SWDR_AP_DAR22, "DAR22" },
+    { SWDRegisters::SWDR_AP_DAR23, "DAR23" },
+    { SWDRegisters::SWDR_AP_DAR24, "DAR24" },
+    { SWDRegisters::SWDR_AP_DAR25, "DAR25" },
+    { SWDRegisters::SWDR_AP_DAR26, "DAR26" },
+    { SWDRegisters::SWDR_AP_DAR27, "DAR27" },
+    { SWDRegisters::SWDR_AP_DAR28, "DAR28" },
+    { SWDRegisters::SWDR_AP_DAR29, "DAR29" },
+    { SWDRegisters::SWDR_AP_DAR30, "DAR30" },
+    { SWDRegisters::SWDR_AP_DAR31, "DAR31" },
+    { SWDRegisters::SWDR_AP_DAR32, "DAR32" },
+    { SWDRegisters::SWDR_AP_DAR33, "DAR33" },
+    { SWDRegisters::SWDR_AP_DAR34, "DAR34" },
+    { SWDRegisters::SWDR_AP_DAR35, "DAR35" },
+    { SWDRegisters::SWDR_AP_DAR36, "DAR36" },
+    { SWDRegisters::SWDR_AP_DAR37, "DAR37" },
+    { SWDRegisters::SWDR_AP_DAR38, "DAR38" },
+    { SWDRegisters::SWDR_AP_DAR39, "DAR39" },
+    { SWDRegisters::SWDR_AP_DAR40, "DAR40" },
+    { SWDRegisters::SWDR_AP_DAR41, "DAR41" },
+    { SWDRegisters::SWDR_AP_DAR42, "DAR42" },
+    { SWDRegisters::SWDR_AP_DAR43, "DAR43" },
+    { SWDRegisters::SWDR_AP_DAR44, "DAR44" },
+    { SWDRegisters::SWDR_AP_DAR45, "DAR45" },
+    { SWDRegisters::SWDR_AP_DAR46, "DAR46" },
+    { SWDRegisters::SWDR_AP_DAR47, "DAR47" },
+    { SWDRegisters::SWDR_AP_DAR48, "DAR48" },
+    { SWDRegisters::SWDR_AP_DAR49, "DAR49" },
+    { SWDRegisters::SWDR_AP_DAR50, "DAR50" },
+    { SWDRegisters::SWDR_AP_DAR51, "DAR51" },
+    { SWDRegisters::SWDR_AP_DAR52, "DAR52" },
+    { SWDRegisters::SWDR_AP_DAR53, "DAR53" },
+    { SWDRegisters::SWDR_AP_DAR54, "DAR54" },
+    { SWDRegisters::SWDR_AP_DAR55, "DAR55" },
+    { SWDRegisters::SWDR_AP_DAR56, "DAR56" },
+    { SWDRegisters::SWDR_AP_DAR57, "DAR57" },
+    { SWDRegisters::SWDR_AP_DAR58, "DAR58" },
+    { SWDRegisters::SWDR_AP_DAR59, "DAR59" },
+    { SWDRegisters::SWDR_AP_DAR60, "DAR60" },
+    { SWDRegisters::SWDR_AP_DAR61, "DAR61" },
+    { SWDRegisters::SWDR_AP_DAR62, "DAR62" },
+    { SWDRegisters::SWDR_AP_DAR63, "DAR63" },
+    { SWDRegisters::SWDR_AP_DAR64, "DAR64" },
+    { SWDRegisters::SWDR_AP_DAR65, "DAR65" },
+    { SWDRegisters::SWDR_AP_DAR66, "DAR66" },
+    { SWDRegisters::SWDR_AP_DAR67, "DAR67" },
+    { SWDRegisters::SWDR_AP_DAR68, "DAR68" },
+    { SWDRegisters::SWDR_AP_DAR69, "DAR69" },
+    { SWDRegisters::SWDR_AP_DAR70, "DAR70" },
+    { SWDRegisters::SWDR_AP_DAR71, "DAR71" },
+    { SWDRegisters::SWDR_AP_DAR72, "DAR72" },
+    { SWDRegisters::SWDR_AP_DAR73, "DAR73" },
+    { SWDRegisters::SWDR_AP_DAR74, "DAR74" },
+    { SWDRegisters::SWDR_AP_DAR75, "DAR75" },
+    { SWDRegisters::SWDR_AP_DAR76, "DAR76" },
+    { SWDRegisters::SWDR_AP_DAR77, "DAR77" },
+    { SWDRegisters::SWDR_AP_DAR78, "DAR78" },
+    { SWDRegisters::SWDR_AP_DAR79, "DAR79" },
+    { SWDRegisters::SWDR_AP_DAR80, "DAR80" },
+    { SWDRegisters::SWDR_AP_DAR81, "DAR81" },
+    { SWDRegisters::SWDR_AP_DAR82, "DAR82" },
+    { SWDRegisters::SWDR_AP_DAR83, "DAR83" },
+    { SWDRegisters::SWDR_AP_DAR84, "DAR84" },
+    { SWDRegisters::SWDR_AP_DAR85, "DAR85" },
+    { SWDRegisters::SWDR_AP_DAR86, "DAR86" },
+    { SWDRegisters::SWDR_AP_DAR87, "DAR87" },
+    { SWDRegisters::SWDR_AP_DAR88, "DAR88" },
+    { SWDRegisters::SWDR_AP_DAR89, "DAR89" },
+    { SWDRegisters::SWDR_AP_DAR90, "DAR90" },
+    { SWDRegisters::SWDR_AP_DAR91, "DAR91" },
+    { SWDRegisters::SWDR_AP_DAR92, "DAR92" },
+    { SWDRegisters::SWDR_AP_DAR93, "DAR93" },
+    { SWDRegisters::SWDR_AP_DAR94, "DAR94" },
+    { SWDRegisters::SWDR_AP_DAR95, "DAR95" },
+    { SWDRegisters::SWDR_AP_DAR96, "DAR96" },
+    { SWDRegisters::SWDR_AP_DAR97, "DAR97" },
+    { SWDRegisters::SWDR_AP_DAR98, "DAR98" },
+    { SWDRegisters::SWDR_AP_DAR99, "DAR99" },
+    { SWDRegisters::SWDR_AP_DAR100, "DAR100" },
+    { SWDRegisters::SWDR_AP_DAR101, "DAR101" },
+    { SWDRegisters::SWDR_AP_DAR102, "DAR102" },
+    { SWDRegisters::SWDR_AP_DAR103, "DAR103" },
+    { SWDRegisters::SWDR_AP_DAR104, "DAR104" },
+    { SWDRegisters::SWDR_AP_DAR105, "DAR105" },
+    { SWDRegisters::SWDR_AP_DAR106, "DAR106" },
+    { SWDRegisters::SWDR_AP_DAR107, "DAR107" },
+    { SWDRegisters::SWDR_AP_DAR108, "DAR108" },
+    { SWDRegisters::SWDR_AP_DAR109, "DAR109" },
+    { SWDRegisters::SWDR_AP_DAR110, "DAR110" },
+    { SWDRegisters::SWDR_AP_DAR111, "DAR111" },
+    { SWDRegisters::SWDR_AP_DAR112, "DAR112" },
+    { SWDRegisters::SWDR_AP_DAR113, "DAR113" },
+    { SWDRegisters::SWDR_AP_DAR114, "DAR114" },
+    { SWDRegisters::SWDR_AP_DAR115, "DAR115" },
+    { SWDRegisters::SWDR_AP_DAR116, "DAR116" },
+    { SWDRegisters::SWDR_AP_DAR117, "DAR117" },
+    { SWDRegisters::SWDR_AP_DAR118, "DAR118" },
+    { SWDRegisters::SWDR_AP_DAR119, "DAR119" },
+    { SWDRegisters::SWDR_AP_DAR120, "DAR120" },
+    { SWDRegisters::SWDR_AP_DAR121, "DAR121" },
+    { SWDRegisters::SWDR_AP_DAR122, "DAR122" },
+    { SWDRegisters::SWDR_AP_DAR123, "DAR123" },
+    { SWDRegisters::SWDR_AP_DAR124, "DAR124" },
+    { SWDRegisters::SWDR_AP_DAR125, "DAR125" },
+    { SWDRegisters::SWDR_AP_DAR126, "DAR126" },
+    { SWDRegisters::SWDR_AP_DAR127, "DAR127" },
+    { SWDRegisters::SWDR_AP_DAR128, "DAR128" },
+    { SWDRegisters::SWDR_AP_DAR129, "DAR129" },
+    { SWDRegisters::SWDR_AP_DAR130, "DAR130" },
+    { SWDRegisters::SWDR_AP_DAR131, "DAR131" },
+    { SWDRegisters::SWDR_AP_DAR132, "DAR132" },
+    { SWDRegisters::SWDR_AP_DAR133, "DAR133" },
+    { SWDRegisters::SWDR_AP_DAR134, "DAR134" },
+    { SWDRegisters::SWDR_AP_DAR135, "DAR135" },
+    { SWDRegisters::SWDR_AP_DAR136, "DAR136" },
+    { SWDRegisters::SWDR_AP_DAR137, "DAR137" },
+    { SWDRegisters::SWDR_AP_DAR138, "DAR138" },
+    { SWDRegisters::SWDR_AP_DAR139, "DAR139" },
+    { SWDRegisters::SWDR_AP_DAR140, "DAR140" },
+    { SWDRegisters::SWDR_AP_DAR141, "DAR141" },
+    { SWDRegisters::SWDR_AP_DAR142, "DAR142" },
+    { SWDRegisters::SWDR_AP_DAR143, "DAR143" },
+    { SWDRegisters::SWDR_AP_DAR144, "DAR144" },
+    { SWDRegisters::SWDR_AP_DAR145, "DAR145" },
+    { SWDRegisters::SWDR_AP_DAR146, "DAR146" },
+    { SWDRegisters::SWDR_AP_DAR147, "DAR147" },
+    { SWDRegisters::SWDR_AP_DAR148, "DAR148" },
+    { SWDRegisters::SWDR_AP_DAR149, "DAR149" },
+    { SWDRegisters::SWDR_AP_DAR150, "DAR150" },
+    { SWDRegisters::SWDR_AP_DAR151, "DAR151" },
+    { SWDRegisters::SWDR_AP_DAR152, "DAR152" },
+    { SWDRegisters::SWDR_AP_DAR153, "DAR153" },
+    { SWDRegisters::SWDR_AP_DAR154, "DAR154" },
+    { SWDRegisters::SWDR_AP_DAR155, "DAR155" },
+    { SWDRegisters::SWDR_AP_DAR156, "DAR156" },
+    { SWDRegisters::SWDR_AP_DAR157, "DAR157" },
+    { SWDRegisters::SWDR_AP_DAR158, "DAR158" },
+    { SWDRegisters::SWDR_AP_DAR159, "DAR159" },
+    { SWDRegisters::SWDR_AP_DAR160, "DAR160" },
+    { SWDRegisters::SWDR_AP_DAR161, "DAR161" },
+    { SWDRegisters::SWDR_AP_DAR162, "DAR162" },
+    { SWDRegisters::SWDR_AP_DAR163, "DAR163" },
+    { SWDRegisters::SWDR_AP_DAR164, "DAR164" },
+    { SWDRegisters::SWDR_AP_DAR165, "DAR165" },
+    { SWDRegisters::SWDR_AP_DAR166, "DAR166" },
+    { SWDRegisters::SWDR_AP_DAR167, "DAR167" },
+    { SWDRegisters::SWDR_AP_DAR168, "DAR168" },
+    { SWDRegisters::SWDR_AP_DAR169, "DAR169" },
+    { SWDRegisters::SWDR_AP_DAR170, "DAR170" },
+    { SWDRegisters::SWDR_AP_DAR171, "DAR171" },
+    { SWDRegisters::SWDR_AP_DAR172, "DAR172" },
+    { SWDRegisters::SWDR_AP_DAR173, "DAR173" },
+    { SWDRegisters::SWDR_AP_DAR174, "DAR174" },
+    { SWDRegisters::SWDR_AP_DAR175, "DAR175" },
+    { SWDRegisters::SWDR_AP_DAR176, "DAR176" },
+    { SWDRegisters::SWDR_AP_DAR177, "DAR177" },
+    { SWDRegisters::SWDR_AP_DAR178, "DAR178" },
+    { SWDRegisters::SWDR_AP_DAR179, "DAR179" },
+    { SWDRegisters::SWDR_AP_DAR180, "DAR180" },
+    { SWDRegisters::SWDR_AP_DAR181, "DAR181" },
+    { SWDRegisters::SWDR_AP_DAR182, "DAR182" },
+    { SWDRegisters::SWDR_AP_DAR183, "DAR183" },
+    { SWDRegisters::SWDR_AP_DAR184, "DAR184" },
+    { SWDRegisters::SWDR_AP_DAR185, "DAR185" },
+    { SWDRegisters::SWDR_AP_DAR186, "DAR186" },
+    { SWDRegisters::SWDR_AP_DAR187, "DAR187" },
+    { SWDRegisters::SWDR_AP_DAR188, "DAR188" },
+    { SWDRegisters::SWDR_AP_DAR189, "DAR189" },
+    { SWDRegisters::SWDR_AP_DAR190, "DAR190" },
+    { SWDRegisters::SWDR_AP_DAR191, "DAR191" },
+    { SWDRegisters::SWDR_AP_DAR192, "DAR192" },
+    { SWDRegisters::SWDR_AP_DAR193, "DAR193" },
+    { SWDRegisters::SWDR_AP_DAR194, "DAR194" },
+    { SWDRegisters::SWDR_AP_DAR195, "DAR195" },
+    { SWDRegisters::SWDR_AP_DAR196, "DAR196" },
+    { SWDRegisters::SWDR_AP_DAR197, "DAR197" },
+    { SWDRegisters::SWDR_AP_DAR198, "DAR198" },
+    { SWDRegisters::SWDR_AP_DAR199, "DAR199" },
+    { SWDRegisters::SWDR_AP_DAR200, "DAR200" },
+    { SWDRegisters::SWDR_AP_DAR201, "DAR201" },
+    { SWDRegisters::SWDR_AP_DAR202, "DAR202" },
+    { SWDRegisters::SWDR_AP_DAR203, "DAR203" },
+    { SWDRegisters::SWDR_AP_DAR204, "DAR204" },
+    { SWDRegisters::SWDR_AP_DAR205, "DAR205" },
+    { SWDRegisters::SWDR_AP_DAR206, "DAR206" },
+    { SWDRegisters::SWDR_AP_DAR207, "DAR207" },
+    { SWDRegisters::SWDR_AP_DAR208, "DAR208" },
+    { SWDRegisters::SWDR_AP_DAR209, "DAR209" },
+    { SWDRegisters::SWDR_AP_DAR210, "DAR210" },
+    { SWDRegisters::SWDR_AP_DAR211, "DAR211" },
+    { SWDRegisters::SWDR_AP_DAR212, "DAR212" },
+    { SWDRegisters::SWDR_AP_DAR213, "DAR213" },
+    { SWDRegisters::SWDR_AP_DAR214, "DAR214" },
+    { SWDRegisters::SWDR_AP_DAR215, "DAR215" },
+    { SWDRegisters::SWDR_AP_DAR216, "DAR216" },
+    { SWDRegisters::SWDR_AP_DAR217, "DAR217" },
+    { SWDRegisters::SWDR_AP_DAR218, "DAR218" },
+    { SWDRegisters::SWDR_AP_DAR219, "DAR219" },
+    { SWDRegisters::SWDR_AP_DAR220, "DAR220" },
+    { SWDRegisters::SWDR_AP_DAR221, "DAR221" },
+    { SWDRegisters::SWDR_AP_DAR222, "DAR222" },
+    { SWDRegisters::SWDR_AP_DAR223, "DAR223" },
+    { SWDRegisters::SWDR_AP_DAR224, "DAR224" },
+    { SWDRegisters::SWDR_AP_DAR225, "DAR225" },
+    { SWDRegisters::SWDR_AP_DAR226, "DAR226" },
+    { SWDRegisters::SWDR_AP_DAR227, "DAR227" },
+    { SWDRegisters::SWDR_AP_DAR228, "DAR228" },
+    { SWDRegisters::SWDR_AP_DAR229, "DAR229" },
+    { SWDRegisters::SWDR_AP_DAR230, "DAR230" },
+    { SWDRegisters::SWDR_AP_DAR231, "DAR231" },
+    { SWDRegisters::SWDR_AP_DAR232, "DAR232" },
+    { SWDRegisters::SWDR_AP_DAR233, "DAR233" },
+    { SWDRegisters::SWDR_AP_DAR234, "DAR234" },
+    { SWDRegisters::SWDR_AP_DAR235, "DAR235" },
+    { SWDRegisters::SWDR_AP_DAR236, "DAR236" },
+    { SWDRegisters::SWDR_AP_DAR237, "DAR237" },
+    { SWDRegisters::SWDR_AP_DAR238, "DAR238" },
+    { SWDRegisters::SWDR_AP_DAR239, "DAR239" },
+    { SWDRegisters::SWDR_AP_DAR240, "DAR240" },
+    { SWDRegisters::SWDR_AP_DAR241, "DAR241" },
+    { SWDRegisters::SWDR_AP_DAR242, "DAR242" },
+    { SWDRegisters::SWDR_AP_DAR243, "DAR243" },
+    { SWDRegisters::SWDR_AP_DAR244, "DAR244" },
+    { SWDRegisters::SWDR_AP_DAR245, "DAR245" },
+    { SWDRegisters::SWDR_AP_DAR246, "DAR246" },
+    { SWDRegisters::SWDR_AP_DAR247, "DAR247" },
+    { SWDRegisters::SWDR_AP_DAR248, "DAR248" },
+    { SWDRegisters::SWDR_AP_DAR249, "DAR249" },
+    { SWDRegisters::SWDR_AP_DAR250, "DAR250" },
+    { SWDRegisters::SWDR_AP_DAR251, "DAR251" },
+    { SWDRegisters::SWDR_AP_DAR252, "DAR252" },
+    { SWDRegisters::SWDR_AP_DAR253, "DAR253" },
+    { SWDRegisters::SWDR_AP_DAR254, "DAR254" },
+    { SWDRegisters::SWDR_AP_DAR255, "DAR255" },
+    { SWDRegisters::SWDR_AP_TRR, "TRR" },
+    { SWDRegisters::SWDR_AP_T0TR, "T0TR" },
+    { SWDRegisters::SWDR_AP_CFG1, "CFG1" },
+    { SWDRegisters::SWDR_AP_ITCTRL, "ITCTRL" },
+    { SWDRegisters::SWDR_AP_CLAIMSET, "CLAIMSET" },
+    { SWDRegisters::SWDR_AP_CLAIMCLR, "CLAIMCLR" },
+    { SWDRegisters::SWDR_AP_DEVAFF0, "DEVAFF0" },
+    { SWDRegisters::SWDR_AP_DEVAFF1, "DEVAFF1" },
+    { SWDRegisters::SWDR_AP_LAR, "LAR" },
+    { SWDRegisters::SWDR_AP_LSR, "LSR" },
+    { SWDRegisters::SWDR_AP_AUTHSTATUS, "AUTHSTATUS" },
+    { SWDRegisters::SWDR_AP_DEVARCH, "DEVARCH" },
+    { SWDRegisters::SWDR_AP_DEVID2, "DEVID2" },
+    { SWDRegisters::SWDR_AP_DEVID1, "DEVID1" },
+    { SWDRegisters::SWDR_AP_DEVID, "DEVID" },
+    { SWDRegisters::SWDR_AP_DEVTYPE, "DEVTYPE" },
+    { SWDRegisters::SWDR_AP_PIDR4, "PIDR4" },
+    { SWDRegisters::SWDR_AP_PIDR5, "PIDR5" },
+    { SWDRegisters::SWDR_AP_PIDR6, "PIDR6" },
+    { SWDRegisters::SWDR_AP_PIDR7, "PIDR7" },
+    { SWDRegisters::SWDR_AP_PIDR0, "PIDR0" },
+    { SWDRegisters::SWDR_AP_PIDR1, "PIDR1" },
+    { SWDRegisters::SWDR_AP_PIDR2, "PIDR2" },
+    { SWDRegisters::SWDR_AP_PIDR3, "PIDR3" },
+    { SWDRegisters::SWDR_AP_CIDR0, "CIDR0" },
+    { SWDRegisters::SWDR_AP_CIDR1, "CIDR1" },
+    { SWDRegisters::SWDR_AP_CIDR2, "CIDR2" },
+    { SWDRegisters::SWDR_AP_CIDR3, "CIDR3" }
+};
+
 std::string GetRegisterName( SWDRegisters reg )
 {
-    switch( reg )
+    auto search = REGISTER_NAMES.find( reg );
+    if( search != REGISTER_NAMES.end() )
     {
-    case SWDR_DP_IDCODE:
-        return "IDCODE";
-    case SWDR_DP_ABORT:
-        return "ABORT";
-    case SWDR_DP_CTRL_STAT:
-        return "CTRL/STAT";
-    case SWDR_DP_WCR:
-        return "WCR";
-    case SWDR_DP_RESEND:
-        return "RESEND";
-    case SWDR_DP_SELECT:
-        return "SELECT";
-    case SWDR_DP_RDBUFF:
-        return "RDBUFF";
-    case SWDR_DP_ROUTESEL:
-        return "ROUTESEL";
-
-    case SWDR_AP_CSW:
-        return "CSW";
-    case SWDR_AP_TAR:
-        return "TAR";
-    case SWDR_AP_DRW:
-        return "DRW";
-    case SWDR_AP_BD0:
-        return "BD0";
-    case SWDR_AP_BD1:
-        return "BD1";
-    case SWDR_AP_BD2:
-        return "BD2";
-    case SWDR_AP_BD3:
-        return "BD3";
-    case SWDR_AP_CFG:
-        return "CFG";
-    case SWDR_AP_BASE:
-        return "BASE";
-    case SWDR_AP_RAZ_WI:
-        return "RAZ_WI";
-    case SWDR_AP_IDR:
-        return "IDR";
+        return search->second;
     }
-
-    return "??";
+    else
+    {
+        return REGISTER_NAMES.at( SWDRegisters::SWDR_UNDEFINED );
+    }
 }
 
-std::string GetRegisterValueDesc( SWDRegisters reg, U32 val, DisplayBase display_base )
+std::string GetRegisterValueDesc( SWDRegisters reg, U32 val, DisplayBase displayBase, DPVersion version )
 {
-    std::string ret_val;
+    std::string retVal;
 
     switch( reg )
     {
-    case SWDR_DP_IDCODE:
-        ret_val = "DESIGNER=" + int2str_sal( val & 0xfff, display_base, 12 );
-        ret_val += ", PARTNO=" + int2str_sal( ( val >> 12 ) & 0xffff, display_base, 16 );
-        ret_val += ", Version=" + int2str_sal( ( val >> 28 ) & 0xf, display_base, 4 );
-        break;
-    case SWDR_DP_ABORT:
-        ret_val = std::string( "ORUNERRCLR=" ) + ( ( val & 16 ) ? "1" : "0" );
-        ret_val += std::string( ", WDERRCLR=" ) + ( ( val & 8 ) ? "1" : "0" );
-        ret_val += std::string( ", STKERRCLR=" ) + ( ( val & 4 ) ? "1" : "0" );
-        ret_val += std::string( ", STKCMPCLR=" ) + ( ( val & 2 ) ? "1" : "0" );
-        ret_val += std::string( ", DAPABORT=" ) + ( ( val & 1 ) ? "1" : "0" );
-        break;
+        case SWDRegisters::SWDR_DP_DPIDR:
+            retVal = std::string( "DESIGNER=" ) + Int2StrSal( val & 0x0fffu, displayBase, 12u );
+            retVal += std::string( ", VERSION=" ) + Int2StrSal( ( val >> 12u ) & 0x0fu, displayBase, 4u );
+            retVal += std::string( ", MIN=" ) + ( ( ( ( val >> 16u ) & 0x01u ) == 0 ) ? "YES" : "NO" );
+            retVal += std::string( ", PARTNO=" ) + Int2StrSal( ( val >> 20u ) & 0xffu, displayBase, 8u );
+            retVal += std::string( ", REVISION=" ) + Int2StrSal( ( val >> 28u ) & 0x0fu, displayBase, 4u );
+            break;
 
-    case SWDR_DP_CTRL_STAT:
-        ret_val = std::string( "CSYSPWRUPACK=" ) + ( ( val & ( 1 << 31 ) ) ? "1" : "0" );
-        ret_val += std::string( ", CSYSPWRUPREQ=" ) + ( ( val & ( 1 << 30 ) ) ? "1" : "0" );
-        ret_val += std::string( ", CDBGPWRUPACK=" ) + ( ( val & ( 1 << 29 ) ) ? "1" : "0" );
-        ret_val += std::string( ", CDBGPWRUPREQ=" ) + ( ( val & ( 1 << 28 ) ) ? "1" : "0" );
-        ret_val += std::string( ", CDBGRSTACK=" ) + ( ( val & ( 1 << 27 ) ) ? "1" : "0" );
-        ret_val += std::string( ", CDBGRSTREQ=" ) + ( ( val & ( 1 << 26 ) ) ? "1" : "0" );
-        ret_val += ", TRNCNT=" + int2str_sal( ( val >> 12 ) & 0xfff, display_base, 12 );
-        ret_val += ", MASKLANE=" + int2str_sal( ( val >> 8 ) & 0xf, display_base, 4 );
-        ret_val += std::string( ", WDATAERR=" ) + ( ( val & ( 1 << 7 ) ) ? "1" : "0" );
-        ret_val += std::string( ", READOK=" ) + ( ( val & ( 1 << 6 ) ) ? "1" : "0" );
-        ret_val += std::string( ", STICKYERR=" ) + ( ( val & ( 1 << 5 ) ) ? "1" : "0" );
-        ret_val += std::string( ", STICKYCMP=" ) + ( ( val & ( 1 << 4 ) ) ? "1" : "0" );
-        ret_val += ", TRNMODE=";
-        switch( ( val >> 2 ) & 3 )
-        {
-        case 0:
-            ret_val += "Normal";
+        case SWDRegisters::SWDR_DP_ABORT:
+            retVal = std::string( "ORUNERRCLR=" ) + ( ( val & 16u ) ? "1" : "0" );
+            retVal += std::string( ", WDERRCLR=" ) + ( ( val & 8u ) ? "1" : "0" );
+            retVal += std::string( ", STKERRCLR=" ) + ( ( val & 4u ) ? "1" : "0" );
+            retVal += std::string( ", STKCMPCLR=" ) + ( ( val & 2u ) ? "1" : "0" );
+            retVal += std::string( ", DAPABORT=" ) + ( ( val & 1u ) ? "1" : "0" );
             break;
-        case 1:
-            ret_val += "Pushed verify";
+
+        case SWDRegisters::SWDR_DP_CTRL_STAT:
+            retVal = std::string( "CSYSPWRUPACK=" ) + ( ( val & ( 1u << 31u ) ) ? "1" : "0" );
+            retVal += std::string( ", CSYSPWRUPREQ=" ) + ( ( val & ( 1u << 30u ) ) ? "1" : "0" );
+            retVal += std::string( ", CDBGPWRUPACK=" ) + ( ( val & ( 1u << 29u ) ) ? "1" : "0" );
+            retVal += std::string( ", CDBGPWRUPREQ=" ) + ( ( val & ( 1u << 28u ) ) ? "1" : "0" );
+            retVal += std::string( ", CDBGRSTACK=" ) + ( ( val & ( 1u << 27u ) ) ? "1" : "0" );
+            retVal += std::string( ", CDBGRSTREQ=" ) + ( ( val & ( 1u << 26u ) ) ? "1" : "0" );
+            if( version >= DPVersion::DP_V3 )
+            {
+                // available starting from DPv3
+                retVal += std::string( ", ERRMODE=" ) + ( ( val & ( 1u << 24u ) ) ? "1" : "0" );
+            }
+            retVal += ", TRNCNT=" + Int2StrSal( ( val >> 12u ) & 0x0fffu, displayBase, 12u );
+            retVal += ", MASKLANE=" + Int2StrSal( ( val >> 8u ) & 0x0fu, displayBase, 4u );
+            retVal += std::string( ", WDATAERR=" ) + ( ( val & ( 1u << 7u ) ) ? "1" : "0" );
+            retVal += std::string( ", READOK=" ) + ( ( val & ( 1u << 6u ) ) ? "1" : "0" );
+            retVal += std::string( ", STICKYERR=" ) + ( ( val & ( 1u << 5u ) ) ? "1" : "0" );
+            retVal += std::string( ", STICKYCMP=" ) + ( ( val & ( 1u << 4u ) ) ? "1" : "0" );
+            retVal += ", TRNMODE=";
+            switch( ( val >> 2u ) & 3u )
+            {
+                case 0u:
+                    retVal += "Normal";
+                    break;
+                case 1u:
+                    retVal += "Pushed verify";
+                    break;
+                case 2u:
+                    retVal += "Pushed compare";
+                    break;
+                case 3u:
+                    retVal += "Reserved";
+                    break;
+                }
+            retVal += std::string( ", STICKYORUN=" ) + ( ( val & ( 1u << 1u ) ) ? "1" : "0" );
+            retVal += std::string( ", ORUNDETECT=" ) + ( ( val & ( 1u << 0u ) ) ? "1" : "0" );
             break;
-        case 2:
-            ret_val += "Pushed compare";
+
+        case SWDRegisters::SWDR_DP_DLCR:
+            retVal = "TURNAROUND=" + Int2StrSal( ( val >> 8u ) & 3u, displayBase, 2u );
+            retVal += " (" + Int2StrSal( ( ( val >> 8u ) & 3u ) + 1u, Decimal, 2u ) + " data period(s))";
+            if( version == DPVersion::DP_V1 )
+            {
+                retVal += ", WIREMODE=" + Int2StrSal( ( val >> 4u ) & 0x0f, displayBase, 4u ) + " ";
+                switch( ( val >> 6u ) & 3u )
+                {
+                    case 0u:
+                        retVal += "Asynchronous";
+                        break;
+                    case 1u:
+                        retVal += "Synchronous";
+                        break;
+                    default:
+                        retVal += "Reserved";
+                        break;
+                }
+                retVal += ", PRESCALER=" + Int2StrSal( val & 3u, displayBase, 2u );
+            }
             break;
-        case 3:
-            ret_val += "Reserved";
+
+        case SWDRegisters::SWDR_DP_TARGETID:
+            if( version >= DPVersion::DP_V2 )
+            {
+                // available starting from DPv2
+                retVal = std::string( "TREVISION=" ) + Int2StrSal( ( val >> 28u ) & 0xfu, displayBase );
+                retVal += ", TPARTNO=" + Int2StrSal( ( val >> 12u ) & 0xffffu, displayBase );
+                retVal += ", TDESIGNER=" + Int2StrSal( ( val >> 1u ) & 0x7ffu, displayBase );
+            }
             break;
-        }
-        ret_val += std::string( ", STICKYORUN=" ) + ( ( val & ( 1 << 1 ) ) ? "1" : "0" );
-        ret_val += std::string( ", ORUNDETECT=" ) + ( ( val & ( 1 << 0 ) ) ? "1" : "0" );
-        break;
-    case SWDR_DP_WCR:
-        ret_val = "TURNAROUND=" + int2str_sal( ( val >> 8 ) & 3, display_base, 2 ) + " data period(s)";
-        ret_val += ", WIREMODE=" + int2str_sal( ( val >> 4 ) & 0xf, display_base, 4 );
-        switch( ( val >> 6 ) & 3 )
-        {
-        case 0:
-            ret_val += "Asynchronous";
+
+        case SWDRegisters::SWDR_DP_DLPIDR:
+            if( version >= DPVersion::DP_V2 )
+            {
+                // available starting from DPv2
+                retVal = std::string( "TINSTANCE=" ) + Int2StrSal( ( val >> 28u ) & 0xfu, displayBase );
+                retVal += ", PROTVSN=" + Int2StrSal( val & 0x0fu, displayBase ) + " ";
+                retVal += ( ( val & 0x0fu ) == 1u ) ? "(SWD protocol version 2)" : "(Reserved)";
+            }
             break;
-        case 1:
-            ret_val += "Synchronous";
+
+        case SWDRegisters::SWDR_DP_BASEPTR0:
+            if( version == DPVersion::DP_V3 )
+            {
+                retVal = "PTR=" + Int2StrSal( ( val >> 12u ) & 0xfffffu, displayBase );
+                retVal += std::string( ", VALID=" ) + ( ( val & 1u ) ? "1" : "0" );
+            }
+            break;
+
+        case SWDRegisters::SWDR_DP_EVENTSTAT:
+            if( version >= DPVersion::DP_V2 )
+            {
+                // available starting from DPv2
+                retVal = std::string( "EA=" ) + ( ( val & 1u ) ? "1 (There is no event requiring attention)" : "0 (An event requires attention)" );
+            }
+            break;
+
+            // case SWDR_DP_RESEND:     break;      // just raw data
+
+        case SWDRegisters::SWDR_DP_SELECT:
+            if( version < DPVersion::DP_V3 )
+            {
+                retVal = "APSEL=" + Int2StrSal( ( val >> 24u ) & 0xffu, displayBase );
+                retVal += ", APBANKSEL=" + Int2StrSal( ( val >> 4u ) & 0x0fu, displayBase, 4u );
+            }
+            else
+            {
+                retVal = "APBANKADDR=" + Int2StrSal( val & 0xFFFFFFF0u, displayBase );
+            }
+            retVal += ", DPBANKSEL=" + Int2StrSal( val & 0xFu, displayBase, 4u );
+            break;
+
+        // case SWDR_DP_RDBUFF:     break;      // just raw data
+        // case SWDR_DP_ROUTESEL:       break;      // just raw data
+
+        case SWDRegisters::SWDR_DP_DPIDR1:
+            retVal = std::string( "ERRMODE=" ) + ( ( val & ( 1u << 7u ) ) ? "1" : "0" );
+            retVal += ", ASIZE=" + Int2StrSal( val & 0x7Fu, displayBase, 7u );
+            break;
+
+        // AP
+        case SWDRegisters::SWDR_AP_IDR:
+            retVal = "Revision=" + Int2StrSal( val >> 28u, displayBase, 4u );
+            retVal += ", JEP-106 continuation=" + Int2StrSal( ( val >> 24u ) & 0x0fu, displayBase, 4u );
+            retVal += ", JEP-106 identity=" + Int2StrSal( ( val >> 17u ) & 0x7fu, displayBase, 7u );
+            retVal +=
+                std::string( ", Class=" ) + ( ( val & ( 1u << 16u ) ) ? "This AP is a Memory Acces Port" : "This AP is not a Memory Acces Port" );
+            retVal += ", AP Identfication=" + Int2StrSal( val & 0xffu, displayBase );
+            break;
+        case SWDRegisters::SWDR_AP_CSW:
+            retVal = std::string( "DbgSwEnable=" ) + ( ( val & ( 1u << 31u ) ) ? "1" : "0" );
+            retVal += ", Prot=" + Int2StrSal( ( val >> 24u ) & 0x7fu, displayBase, 7 );
+            if( version < DPVersion::DP_V3 )
+            {
+                retVal += std::string( ", SPIDEN=" ) + ( ( val & ( 1u << 23u ) ) ? "1" : "0" );
+            }
+            else
+            {
+                retVal += std::string( ", SDeviceEn=" ) + ( ( val & ( 1u << 23u ) ) ? "1" : "0" );
+                retVal += ", RMEEN=" + Int2StrSal( ( val >> 21u ) & 0x03u, displayBase, 2u );
+                retVal += std::string( ", ERRSTOP=" ) + ( ( val & ( 1u << 17u ) ) ? "1" : "0" );
+                retVal += std::string( ", ERRNPASS=" ) + ( ( val & ( 1u << 16u ) ) ? "1" : "0" );
+                retVal += std::string( ", MTE=" ) + ( ( val & ( 1u << 15u ) ) ? "1" : "0" );
+            }
+            retVal += ", Type=" + Int2StrSal( ( val >> 12u ) & 0x0fu, displayBase, 4u );
+            retVal += ", Mode=" + Int2StrSal( ( val >> 8u ) & 0x0fu, displayBase, 4u );
+            retVal += std::string( ", TrInProg=" ) + ( ( val & ( 1u << 7u ) ) ? "1" : "0" );
+            retVal += std::string( ", DeviceEn=" ) + ( ( val & ( 1u << 6u ) ) ? "1" : "0" );
+            retVal += ", AddrInc=";
+            switch( ( val >> 4u ) & 0x3u )
+            {
+                case 0u:
+                    retVal += "Auto-increment off";
+                    break;
+                case 1u:
+                    retVal += "Increment single";
+                    break;
+                case 2u:
+                    retVal += "Increment packed";
+                    break;
+                default:
+                    retVal += "Reserved";
+                    break;
+            }
+            retVal += ", Size=";
+            switch( val & 0x7u )
+            {
+                case 0u:
+                    retVal += "Byte (8 bits)";
+                    break;
+                case 1u:
+                    retVal += "Halfword (16 bits)";
+                    break;
+                case 2u:
+                    retVal += "Word (32 bits)";
+                    break;
+                case 3u:
+                    retVal += "Doubleword (64-bits)";
+                    break;
+                case 4u:
+                    retVal += "128-bits";
+                    break;
+                case 5u:
+                    retVal += "256-bits";
+                    break;
+                default:
+                    retVal += "Reserved";
+                    break;
+            }
+            break;
+        // case SWDR_AP_TAR:            break;      // these are just raw data
+        // case SWDR_AP_DRW:            break;
+        // case SWDR_AP_BD0:            break;
+        // case SWDR_AP_BD1:            break;
+        // case SWDR_AP_BD2:            break;
+        // case SWDR_AP_BD3:            break;
+        case SWDRegisters::SWDR_AP_CFG:
+            if( version >= DPVersion::DP_V3 )
+            {
+                retVal = "TARINC=" + Int2StrSal( ( val >> 16u ) & 0x0fu, displayBase, 4u );
+                retVal += ", ERR=" + Int2StrSal( ( val >> 8u ) & 0x0fu, displayBase, 4u );
+                retVal += ", DARSIZE=" + Int2StrSal( ( val >> 4u ) & 0x0fu, displayBase, 4u );
+                retVal += std::string( ", RME=" ) + ( ( val & ( 1u << 3u ) ) ? "1" : "0" );
+                retVal += ", ";
+            }
+            else
+            {
+                retVal = "";
+            }
+            if( version >= DPVersion::DP_V2 )
+            {
+                retVal += std::string( "LD=" ) + ( ( val & ( 1u << 2u ) ) ? "1" : "0" );
+                retVal += std::string( ", LA=" ) + ( ( val & ( 1u << 1u ) ) ? "1" : "0" );
+                retVal += ", ";
+            }
+            if( val & 1u )
+                retVal += "Big-endian";
+            else
+                retVal += "Little-endian";
+
+            break;
+        case SWDRegisters::SWDR_AP_BASE:
+            retVal = "BASEADDR=" + Int2StrSal( val >> 12u, displayBase, 20u );
+            retVal += std::string( ", Format=" ) + ( ( val & ( 1u << 1u ) ) ? "1" : "0" );
+            retVal += ", Entry present=";
+            if( val & 1u )
+                retVal += "Debug entry present";
+            else
+                retVal += "No debug entry present";
+
             break;
         default:
-            ret_val += "Reserved";
             break;
-        }
-        break;
-    // case SWDR_DP_RESEND:		break;		// just raw data
-    case SWDR_DP_SELECT:
-        ret_val = "APSEL=" + int2str_sal( ( val >> 24 ) & 0xff, display_base );
-        ret_val += ", APBANKSEL=" + int2str_sal( ( val >> 4 ) & 0xf, display_base, 4 );
-        ret_val += ", PRESCALER=" + int2str_sal( val & 0x3, display_base, 2 );
-        break;
-    // case SWDR_DP_RDBUFF:		break;		// just raw data
-    // case SWDR_DP_ROUTESEL:		break;		// just raw data
-
-    // AP
-    case SWDR_AP_IDR:
-        ret_val = "Revision=" + int2str_sal( val >> 28, display_base, 4 );
-        ret_val += ", JEP-106 continuation=" + int2str_sal( ( val >> 24 ) & 0xf, display_base, 4 );
-        ret_val += ", JEP-106 identity=" + int2str_sal( ( val >> 17 ) & 0x7f, display_base, 7 );
-        ret_val +=
-            std::string( ", Class=" ) + ( ( val & ( 1 << 16 ) ) ? "This AP is a Memory Acces Port" : "This AP is not a Memory Acces Port" );
-        ret_val += ", AP Identfication=" + int2str_sal( val & 0xff, display_base );
-        break;
-    case SWDR_AP_CSW:
-        ret_val = std::string( "DbgSwEnable=" ) + ( ( val & ( 1 << 31 ) ) ? "1" : "0" );
-        ret_val += ", Prot=" + int2str_sal( ( val >> 24 ) & 0x7f, display_base, 7 );
-        ret_val += std::string( ", SPIDEN=" ) + ( ( val & ( 1 << 23 ) ) ? "1" : "0" );
-        ret_val += ", Mode=" + int2str_sal( ( val >> 8 ) & 0xf, display_base, 4 );
-        ret_val += std::string( ", TrInProg=" ) + ( ( val & ( 1 << 7 ) ) ? "1" : "0" );
-        ret_val += std::string( ", DeviceEn=" ) + ( ( val & ( 1 << 6 ) ) ? "1" : "0" );
-        ret_val += ", AddrInc=";
-        switch( ( val >> 4 ) & 0x3 )
-        {
-        case 0:
-            ret_val += "Auto-increment off";
-            break;
-        case 1:
-            ret_val += "Increment single";
-            break;
-        case 2:
-            ret_val += "Increment packed";
-            break;
-        case 3:
-            ret_val += "Reserved";
-            break;
-        }
-        ret_val += ", Size=";
-        switch( val & 0x7 )
-        {
-        case 0:
-            ret_val += "Byte (8 bits)";
-            break;
-        case 1:
-            ret_val += "Halfword (16 bits)";
-            break;
-        case 2:
-            ret_val += "Word (32 bits)";
-            break;
-        default:
-            ret_val += "Reserved";
-            break;
-        }
-
-        break;
-    // case SWDR_AP_TAR:			break;		// these are just raw data
-    // case SWDR_AP_DRW:			break;
-    // case SWDR_AP_BD0:			break;
-    // case SWDR_AP_BD1:			break;
-    // case SWDR_AP_BD2:			break;
-    // case SWDR_AP_BD3:			break;
-    case SWDR_AP_CFG:
-        if( val & 1 )
-            ret_val = "Big-endian";
-        else
-            ret_val = "Little-endian";
-
-        break;
-    case SWDR_AP_BASE:
-        ret_val += "BASEADDR=" + int2str_sal( val >> 12, display_base, 20 );
-        ret_val += std::string( ", Format=" ) + ( ( val & ( 1 << 1 ) ) ? "1" : "0" );
-        ret_val += ", Entry present=";
-        if( val & 1 )
-            ret_val += "Debug entry present";
-        else
-            ret_val += "No debug entry present";
-
-        break;
     }
 
-    return ret_val;
+    return retVal;
 }
 
-std::string int2str( const U8 i )
+std::string Int2Str( const U8 i )
 {
-    char number_str[ 8 ];
-    AnalyzerHelpers::GetNumberString( i, Decimal, 8, number_str, sizeof( number_str ) );
-    return number_str;
+    char numberStr[ 8 ];
+    AnalyzerHelpers::GetNumberString( i, Decimal, 8u, numberStr, sizeof( numberStr ) );
+    return numberStr;
 }
 
-std::string int2str_sal( const U64 i, DisplayBase base, const int max_bits )
+std::string Int2StrSal( const U64 i, DisplayBase base, const U32 maxBits )
 {
-    char number_str[ 256 ];
-    AnalyzerHelpers::GetNumberString( i, base, max_bits, number_str, sizeof( number_str ) );
-    return number_str;
+    char numberStr[ 256 ];
+    AnalyzerHelpers::GetNumberString( i, base, maxBits, numberStr, sizeof( numberStr ) );
+    return numberStr;
 }

--- a/src/SWDUtils.h
+++ b/src/SWDUtils.h
@@ -29,24 +29,7 @@ inline std::string Int2Str( const U64 i )
     return Int2StrSal( i, Decimal, 64 );
 }
 
-// Function template to get the byte of any value
-template <typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
-constexpr U8 GetByteOf( const T value, const std::size_t byteNr )
-{
-    return ( value >> ( 8u * byteNr ) ) & 0xFFu;
-}
 
-// Function template for little endian serialization to U8 vector
-template <typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
-std::vector<U8> ToVectorU8( const T value )
-{
-    std::vector<U8> vector( sizeof( T ) );
-    for( std::size_t i = 0u; i < sizeof( T ); ++i )
-    {
-        vector[ i ] = GetByteOf( value, i );
-    }
-    return vector;
-}
 
 // Template function that generates a bitmask of length 'onecount'.
 // The generated bitmask has ones in the least significant 'onecount' bits.

--- a/src/SWDUtils.h
+++ b/src/SWDUtils.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef SWD_UTILS_H
+#define SWD_UTILS_H
 
 #ifdef _WINDOWS
 #include <windows.h>
@@ -9,15 +10,84 @@
 
 #include "SWDTypes.h"
 
+bool IsApReg( const SWDRegisters reg );
+bool IsApDataReg( const SWDRegisters reg );
+U32 GetMemAddr( const SWDRegisters dataReg, const U32 tar );
+
 // returns string descriptions of the register name and the bits with values
-std::string GetRegisterName( SWDRegisters reg );
-std::string GetRegisterValueDesc( SWDRegisters reg, U32 val, DisplayBase displayBase, DPVersion version );
+std::string GetRegisterName( const SWDRegisters reg );
+std::string GetRegisterValueDesc( const SWDRegisters reg, const U32 val, const DisplayBase displayBase, const DPVersion version,
+                                  const bool isRead );
+std::string GetReadRegisterValueDesc( const SWDRegistersUnion& swdRegCouple, const U32 data, const DisplayBase displayBase,
+                                     const DPVersion version );
+std::string GetWriteRegisterValueDesc( const SWDRegistersUnion& swdRegCouple, const U32 data, const DisplayBase displayBase,
+                                      const DPVersion version );
 
 std::string Int2StrSal( const U64 i, DisplayBase base, const U32 maxBits = 8 );
 inline std::string Int2Str( const U64 i )
 {
     return Int2StrSal( i, Decimal, 64 );
 }
+
+// Function template to get the byte of any value
+template <typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+constexpr U8 GetByteOf( const T value, const std::size_t byteNr )
+{
+    return ( value >> ( 8u * byteNr ) ) & 0xFFu;
+}
+
+// Function template for little endian serialization to U8 vector
+template <typename T, std::enable_if_t<std::is_integral<T>::value, bool> = true>
+std::vector<U8> ToVectorU8( const T value )
+{
+    std::vector<U8> vector( sizeof( T ) );
+    for( std::size_t i = 0u; i < sizeof( T ); ++i )
+    {
+        vector[ i ] = GetByteOf( value, i );
+    }
+    return vector;
+}
+
+// Template function that generates a bitmask of length 'onecount'.
+// The generated bitmask has ones in the least significant 'onecount' bits.
+template <typename T>
+static constexpr T BitMask( const uint8_t onecount )
+{
+    if( onecount == 0u )
+    {
+        return static_cast<T>( 0u );
+    }
+    else
+    {
+        if( onecount > ( sizeof( T ) * CHAR_BIT ) )
+        {
+            return ~static_cast<T>( 0u );
+        }
+        else
+        {
+            return ( ( ~static_cast<T>( 0u ) ) >> ( ( sizeof( T ) * CHAR_BIT ) - onecount ) );
+        }
+    }
+}
+
+// Template function that generates a bitmask from range 'lsb' to 'msb'.
+template <typename T>
+static constexpr T BitMaskRange( const uint8_t msb, const uint8_t lsb )
+{
+    return BitMask<T>( msb ) ^ BitMask<T>( lsb );
+}
+
+struct RegisterFieldDescription
+{
+    const U8 Access; // Register version and access bitmask
+    const U8 FiledMSB; // MSB bit number of bitfield
+    const U8 FiledLSB; // LSB bit number of bitfield
+    const std::string FieldName;
+    const std::map<U32, std::string> ValuesDesc; // Values description if any :)
+    std::string GetStrFieldValue( const U32 regValue, DisplayBase base ) const;
+  private:
+    const U32 GetFieldValue( const U32 regValue ) const;
+};
 
 /*
 // debugging helper functions -- Windows only!!!
@@ -35,3 +105,5 @@ inline void debug(const char* str)
 #endif
 }
 */
+
+#endif // SWD_UTILS_H

--- a/src/SWDUtils.h
+++ b/src/SWDUtils.h
@@ -11,12 +11,12 @@
 
 // returns string descriptions of the register name and the bits with values
 std::string GetRegisterName( SWDRegisters reg );
-std::string GetRegisterValueDesc( SWDRegisters reg, U32 val, DisplayBase display_base );
+std::string GetRegisterValueDesc( SWDRegisters reg, U32 val, DisplayBase displayBase, DPVersion version );
 
-std::string int2str_sal( const U64 i, DisplayBase base, const int max_bits = 8 );
-inline std::string int2str( const U64 i )
+std::string Int2StrSal( const U64 i, DisplayBase base, const U32 maxBits = 8 );
+inline std::string Int2Str( const U64 i )
 {
-    return int2str_sal( i, Decimal, 64 );
+    return Int2StrSal( i, Decimal, 64 );
 }
 
 /*

--- a/src/VersionInfo.cpp
+++ b/src/VersionInfo.cpp
@@ -5,7 +5,7 @@ const struct VersionInfo VersionInfo =
   2u,
   0u,
   0u,
-  111u,
+  108u,
   __DATE__,
   __TIME__,
   "0000000"

--- a/src/VersionInfo.cpp
+++ b/src/VersionInfo.cpp
@@ -5,7 +5,7 @@ const struct VersionInfo VERSION_INFO =
   2u,
   0u,
   0u,
-  116u,
+  21u,
   __DATE__,
   __TIME__,
   "0000000"

--- a/src/VersionInfo.cpp
+++ b/src/VersionInfo.cpp
@@ -1,11 +1,11 @@
 #include "VersionInfo.h"
 
-const struct VersionInfo VersionInfo =
+const struct VersionInfo VERSION_INFO =
 {
   2u,
   0u,
   0u,
-  108u,
+  116u,
   __DATE__,
   __TIME__,
   "0000000"

--- a/src/VersionInfo.cpp
+++ b/src/VersionInfo.cpp
@@ -1,0 +1,12 @@
+#include "VersionInfo.h"
+
+const struct VersionInfo VersionInfo =
+{
+  2u,
+  0u,
+  0u,
+  111u,
+  __DATE__,
+  __TIME__,
+  "0000000"
+};

--- a/src/VersionInfo.h
+++ b/src/VersionInfo.h
@@ -9,9 +9,9 @@ struct VersionInfo
     uint8_t minor;
     uint16_t patch;
     uint32_t build;
-    char *date;
-    char *time;
-    char *hash;
+    const char *date;
+    const char *time;
+    const char *hash;
 };
 
 #endif // VERSIONINFO_H

--- a/src/VersionInfo.h
+++ b/src/VersionInfo.h
@@ -1,0 +1,17 @@
+#ifndef VERSIONINFO_H
+#define VERSIONINFO_H
+
+#include <cinttypes>
+
+struct VersionInfo
+{
+    uint8_t major;
+    uint8_t minor;
+    uint16_t patch;
+    uint32_t build;
+    char *date;
+    char *time;
+    char *hash;
+};
+
+#endif // VERSIONINFO_H


### PR DESCRIPTION
This pull request incorporates changes from #4 and additionally enables the decoding of SWD data and control sequences captured by waveforms, per ARM ADIv5, ADIv5.2, and ADIv6.

A brief list of improvements:

- List of available SWD control sequence elements that can be detected:
  - Line reset ( at least 50 SWCLKTCK cycles with SWDIOTMS HIGH )
  - JTAG-to-SWD (Legacy)
  - SWD-to-JTAG (Legacy)
  - IDLE cycles
  - DS Pre-Selection Alert (at least 8 SWCLKTCK cycles with SWDIOTMS HIGH)
  - DS Selection Alert
  - DS Pre Activation Code
  - JTAG-Test-Logic-Reset (at least 5 SWCLKTCK cycles with SWDIOTMS HIGH)
  - DS-to-JTAG (activation code)
  - JTAG-to-DS
  - DS-to-SWD (activation code)
  - SWD-to-DS
- Introduced current protocol (SWD/JTAG/DS) state machine
- The number of turnaround cycles is set per DLCR register read/write operation
- Sticky overrun behaviour is set per CTRL/STAT.ORUNDETECT read/write operation
- DP and AP version is detected based on the value that is read from DPIDR
- DP and AP register values are decoded according to their version
- Configurable initial values of:
  - Debug Protocol
  - Last sequence
  - DP Version
  - Number of turnaround cycles
  - Sticky overrun behaviour